### PR TITLE
Task00 Dmitry Kudimov ITMO

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ int main()
 
 		// TODO 2.1
 		// Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
-		cl_uint devicesCount = 0;
+		cl_uint devicesCount = CL_UINT_MAX;
 		OCL_SAFE_CALL( clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
 		std::cout << "    Number of OpenCL devices for platform #" << (platformIndex + 1) << " : " << devicesCount << std::endl;
 
@@ -139,31 +139,23 @@ int main()
 				fetch_device_param(device, CL_DEVICE_TYPE, deviceType);
 
 				std::cout << "        Device type: ";
-				switch (deviceType)
-				{
-					case CL_DEVICE_TYPE_DEFAULT:
-						std::cout << "DEFAULT" << std::endl;
-						break;
-					case CL_DEVICE_TYPE_CPU:
-						std::cout << "CPU" << std::endl;
-						break;
-					case CL_DEVICE_TYPE_GPU:
-						std::cout << "GPU" << std::endl;
-						break;
-					case CL_DEVICE_TYPE_ACCELERATOR:
-						std::cout << "ACCELERATOR" << std::endl;
-						break;
-					case CL_DEVICE_TYPE_CUSTOM:
-						std::cout << "CUSTOM" << std::endl;
-						break;
-					default:
-						std::cout << "UNKNOWN" << std::endl;
-						break;
-				}
+
+				if (deviceType & CL_DEVICE_TYPE_DEFAULT)
+					std::cout << "DEFAULT "; 
+				if (deviceType & CL_DEVICE_TYPE_CPU)
+					std::cout << "CPU ";
+				if (deviceType & CL_DEVICE_TYPE_GPU)
+					std::cout << "GPU ";
+				if (deviceType & CL_DEVICE_TYPE_ACCELERATOR)
+					std::cout << "ACCELERATOR ";
+				if (deviceType & CL_DEVICE_TYPE_CUSTOM)
+					std::cout << "CUSTOM ";
+
+				std::cout << std::endl;
 			}
 
 			{
-				cl_ulong deviceGlobalMemory = 0;
+				cl_ulong deviceGlobalMemory = CL_ULONG_MAX;
 				fetch_device_param(device, CL_DEVICE_GLOBAL_MEM_SIZE, deviceGlobalMemory);
 				std::cout << "        Global memory size: " << (deviceGlobalMemory >> 20) << " MB" << std::endl;
 			}
@@ -175,7 +167,7 @@ int main()
 			}
 
 			{
-				cl_uint maxDeviceFrequency = 0;
+				cl_uint maxDeviceFrequency = CL_UINT_MAX;
 				fetch_device_param(device, CL_DEVICE_MAX_CLOCK_FREQUENCY, maxDeviceFrequency);
 				std::cout << "        Max frequency: " << maxDeviceFrequency << std::endl;
 			}


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
(base) kudiko@kudiko-laptop:~/git/GPGPUTasks2025/build$ ./enumDevices 
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) OpenCL
    Vendor name: Intel(R) Corporation
    Number of OpenCL devices for platform #1 : 1
        Device name: 11th Gen Intel(R) Core(TM) i5-1155G7 @ 2.50GHz
        Device type: CPU 
        Global memory size: 15731 MB
        Endianess: Little
        Max frequency: 2500
        Extensions: cl_khr_spirv_linkonce_odr cl_khr_fp64 cl_khr_fp16 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_ext_float_atomics cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_extended_bit_ops cl_khr_icd cl_khr_il_program cl_khr_suggested_local_work_size cl_intel_unified_shared_memory cl_intel_devicelib_assert cl_khr_subgroup_ballot cl_khr_subgroup_shuffle cl_khr_subgroup_shuffle_relative cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_arithmetic cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_clustered_reduce cl_intel_subgroups cl_intel_subgroups_char cl_intel_subgroups_short cl_intel_subgroups_long cl_intel_required_subgroup_size cl_intel_spirv_subgroups cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_intel_device_attribute_query cl_intel_exec_by_local_thread cl_intel_vec_len_hint cl_intel_device_partition_by_names cl_khr_spir cl_khr_image2d_from_buffer cl_intel_concurrent_dispatch cl_khr_device_uuid cl_khr_integer_dot_product cl_khr_command_buffer cl_intel_subgroup_local_block_io
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./enumDevices
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) OpenCL
    Vendor name: Intel(R) Corporation
    Number of OpenCL devices for platform #1 : 1
        Device name: AMD EPYC 7763 64-Core Processor                
        Device type: CPU 
        Global memory size: 15995 MB
        Endianess: Little
        Max frequency: 0
        Extensions: cl_khr_spirv_linkonce_odr cl_khr_fp64 cl_khr_fp16 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_ext_float_atomics cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_extended_bit_ops cl_khr_icd cl_khr_il_program cl_khr_suggested_local_work_size cl_intel_unified_shared_memory cl_intel_devicelib_assert cl_khr_subgroup_ballot cl_khr_subgroup_shuffle cl_khr_subgroup_shuffle_relative cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_arithmetic cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_clustered_reduce cl_intel_subgroups cl_intel_subgroups_char cl_intel_subgroups_short cl_intel_subgroups_long cl_intel_required_subgroup_size cl_intel_spirv_subgroups cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_intel_device_attribute_query cl_intel_exec_by_local_thread cl_intel_vec_len_hint cl_intel_device_partition_by_names cl_khr_spir cl_khr_image2d_from_buffer cl_intel_concurrent_dispatch cl_khr_device_uuid cl_khr_integer_dot_product cl_khr_command_buffer cl_intel_subgroup_local_block_io
</pre>

</p></details>
