### PR TITLE
Task00 Михаил Багринцев ITMO

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,6 @@ cl_int reportErrorsExceptInvalidValue(cl_int err, const std::string &filename, i
 
 #define OCL_SEMI_SAFE_CALL(expr) reportErrorsExceptInvalidValue(expr, __FILE__, __LINE__)
 
-
 std::string getPlatformData(cl_platform_id platform, cl_platform_info param_name, size_t size = 256)
 {
 	std::string data(size, 0);
@@ -88,7 +87,11 @@ std::string getDeviceMemorySize(cl_device_id device_id)
 {
 	cl_ulong memory;
 	OCL_SAFE_CALL(clGetDeviceInfo(device_id, CL_DEVICE_LOCAL_MEM_SIZE, sizeof(cl_ulong), &memory, nullptr));
-	return std::to_string(memory >> 10);
+	if(auto mb = memory >> 20; mb > 0)
+	{
+		return std::to_string(mb) + " mg";
+	}
+	return std::to_string(memory >> 10) + " kb";
 }
 
 int main()
@@ -126,7 +129,7 @@ int main()
 			std::cout << OFFSET1 "Device #" << (deviceIndex + 1) << "/" << devicesCount << "\n";
 			std::cout << OFFSET2 "Device name:    " << getDeviceData(devices[deviceIndex], CL_DEVICE_NAME) << "\n";
 			std::cout << OFFSET2 "Device type:    " << getDeviceType(devices[deviceIndex]) << "\n";
-			std::cout << OFFSET2 "Memory size:    " << getDeviceMemorySize(devices[deviceIndex]) << " mgbt" << "\n";
+			std::cout << OFFSET2 "Memory size:    " << getDeviceMemorySize(devices[deviceIndex]) << "\n";
 			std::cout << OFFSET2 "Device version: " << getDeviceData(devices[deviceIndex], CL_DEVICE_VERSION) << "\n";
 			std::cout << OFFSET2 "Extensions:     " << getDeviceData(devices[deviceIndex], CL_DEVICE_EXTENSIONS) << "\n";
 		}


### PR DESCRIPTION
- Local run:
```
Number of OpenCL platforms: 2
Platform #1/2
    Platform name: Intel(R) OpenCL
    Vendor name:   Intel(R) Corporation
    Device #1/1
        Device name:      AMD Ryzen 9 7900X 12-Core Processor            
        Device type:      CPU
        Global memory sz: 31293MB
        Local memory sz:  256KB
        Device version:   OpenCL 3.0 (Build 0)
        Extensions:       
Platform #2/2
    Platform name: AMD Accelerated Parallel Processing
    Vendor name:   Advanced Micro Devices, Inc.
    Device #1/2
        Device name:      gfx1030
        Device type:      GPU
        Global memory sz: 16368MB
        Local memory sz:  64KB
        Device version:   OpenCL 2.0 
        Extensions:       cl_khr_fp64 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_fp16 cl_khr_gl_sharing cl_amd_device_attribute_query cl_amd_media_ops cl_amd_media_ops2 cl_khr_image2d_from_buffer cl_khr_subgroups cl_khr_depth_images cl_amd_copy_buffer_p2p cl_amd_assembly_program 
    Device #2/2
        Device name:      gfx1036
        Device type:      GPU
        Global memory sz: 15646MB
        Local memory sz:  64KB
        Device version:   OpenCL 2.0 
        Extensions:       cl_khr_fp64 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_3d_image_writes cl_khr_byte_addressable_store cl_khr_fp16 cl_khr_gl_sharing cl_amd_device_attribute_query cl_amd_media_ops cl_amd_media_ops2 cl_khr_image2d_from_buffer cl_khr_subgroups cl_khr_depth_images cl_amd_copy_buffer_p2p cl_amd_assembly_program 
```
- CI run
```
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) OpenCL
    Vendor name:   Intel(R) Corporation
    Device #1/1
        Device name:      AMD EPYC 7763 64-Core Processor                
        Device type:      CPU
        Global memory sz: 15995MB
        Local memory sz:  256KB
        Device version:   OpenCL 3.0 (Build 0)
        Extensions:       
```
        