### PR TITLE
Task00 Artem Bolshov MIPT

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+#include <unordered_map>
 
 template<typename T>
 std::string to_string(T value)
@@ -27,6 +28,12 @@ void reportError(cl_int err, const std::string &filename, int line)
 }
 
 #define OCL_SAFE_CALL(expr) reportError(expr, __FILE__, __LINE__)
+
+static const std::unordered_map<cl_device_type, std::string> device_type_map = {{CL_DEVICE_TYPE_CPU, "CPU"},
+																				{CL_DEVICE_TYPE_GPU, "GPU"},
+																			    {CL_DEVICE_TYPE_ACCELERATOR, "Accelerator"},
+																			    {CL_DEVICE_TYPE_DEFAULT, "Default"}, 
+																			    {CL_DEVICE_TYPE_CUSTOM, "Custom"}};
 
 int main()
 {
@@ -55,6 +62,7 @@ int main()
 		// Не забывайте проверять коды ошибок с помощью макроса OCL_SAFE_CALL
 		size_t platformNameSize = 0;
 		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, 0, nullptr, &platformNameSize));
+		// OCL_SAFE_CALL(clGetPlatformInfo(platform, 42, 0, nullptr, &platformNameSize));
 		// TODO 1.1
 		// Попробуйте вместо CL_PLATFORM_NAME передать какое-нибудь случайное число - например 239
 		// Т.к. это некорректный идентификатор параметра платформы - то метод вернет код ошибки
@@ -70,15 +78,32 @@ int main()
 		// TODO 1.2
 		// Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
 		std::vector<unsigned char> platformName(platformNameSize, 0);
-		// clGetPlatformInfo(...);
+		size_t actual_size = 0;
+		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), &actual_size));
 		std::cout << "    Platform name: " << platformName.data() << std::endl;
+		std::cout << "    Actual size: " << actual_size << std::endl;
 
 		// TODO 1.3
 		// Запросите и напечатайте так же в консоль вендора данной платформы
+		// compute length of CL_PLATFORM_VENDOR
+		size_t vendor_name_size = 0;
+		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &vendor_name_size));
+
+		std::vector<unsigned char> vendor_name(vendor_name_size, 0);
+		actual_size = 0;
+		OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, vendor_name_size, vendor_name.data(), &actual_size));
+		std::cout << "    Platform vendor: " << vendor_name.data() << std::endl;
+		std::cout << "    Actual size: " << actual_size << std::endl;
 
 		// TODO 2.1
 		// Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
 		cl_uint devicesCount = 0;
+		OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+		std::cout << "    Number of devices: " << devicesCount << std::endl;
+		
+		// allocate array of device ids
+		std::vector<cl_device_id> devices(devicesCount);
+		OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), &devicesCount));
 
 		for(int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex)
 		{
@@ -88,6 +113,47 @@ int main()
 			// - Тип устройства (видеокарта/процессор/что-то странное)
 			// - Размер памяти устройства в мегабайтах
 			// - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+			
+			// get id of current device
+			cl_device_id current_device_id = devices[deviceIndex];
+			std::cout << "    device number " << deviceIndex << ", device ID: " << current_device_id << std::endl; 
+			
+			// request len of value size
+			size_t value_size = 0;
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DEVICE_NAME, 0, nullptr, &value_size));
+
+			std::vector<unsigned char> value(value_size, 0);
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DEVICE_NAME, value_size, value.data(), &value_size));
+			std::cout << "        Device name: " << value.data() << std::endl;
+			
+			value_size = 0;
+			cl_ulong mem_size = 0;
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(cl_ulong), &mem_size, &value_size));
+			std::cout << "        Memory size: " << mem_size/1024/1024 << " Mb" << std::endl;
+
+			value_size = 0;
+			cl_device_type device_type = 0;
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DEVICE_TYPE, sizeof(cl_device_type), &device_type, &value_size));
+			if (device_type_map.count(device_type))
+			{
+				std::cout << "        Device type: " << device_type_map.at(device_type) << std::endl;
+			}
+			else
+			{
+				std::cout << "        Device type: Unknown" << std::endl;
+			}
+
+			value_size = 0;
+			value.clear();
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DRIVER_VERSION, 0, nullptr, &value_size));
+			value.reserve(value_size);
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DRIVER_VERSION, value_size, value.data(), &value_size));
+			std::cout << "        Driver version: " << value.data() << std::endl;
+
+			value_size = 0;
+			cl_bool has_compiler = false;
+			OCL_SAFE_CALL(clGetDeviceInfo(current_device_id, CL_DEVICE_COMPILER_AVAILABLE, sizeof(cl_bool), &has_compiler, &value_size));
+			std::cout << "        Has compiler: " << has_compiler << std::endl;
 		}
 	}
 


### PR DESCRIPTION
Local output: 
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Apple
    Actual size: 6
    Platform vendor: Apple
    Actual size: 6
    Number of devices: 1
    device number 0, device ID: 0x1027f00
        Device name: Apple M1
        Memory size: 10922 Mb
        Device type: GPU
        Driver version: 1.2 1.0
        Has compiler: 1

CI output:
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) OpenCL
    Actual size: 16
    Platform vendor: Intel(R) Corporation
    Actual size: 21
    Number of devices: 1
    device number 0, device ID: 0x563217b9f0d8
        Device name: AMD EPYC 7763 64-Core Processor                
        Memory size: 15995 Mb
        Device type: CPU
        Driver version: 2025.20.8.0.06_160000
        Has compiler: 1