### PR TITLE
Task01 Вячеслав Григорович ITMO

### DIFF
--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -16,5 +17,13 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    const unsigned int index = y * width + x;
+
+    if (index >= width * height) {
+        return;
+    }
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_good(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -16,5 +17,13 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    const unsigned int index = y * width + x;
+
+    if (index >= width * height) {
+        return;
+    }
+
+    c[index] = a[index] + b[index];
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
daredevil2002@i113940737:~/projects/GPGPUTasks2025/build$ ./main_aplusb_matrix 0
Found 3 GPUs in 0.078417 sec (OpenCL: 0.05892 sec, Vulkan: 0.01947 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
  Device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15829/15829 Mb.
Using device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.078176 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.206696 10%=0.213386 median=0.218658 90%=0.331916 max=0.331916)
a + b kernel median VRAM bandwidth: 6.86003 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.018711 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.029746 10%=0.029963 median=0.031037 90%=0.051457 max=0.051457)
a + b kernel median VRAM bandwidth: 48.3294 GB/s

daredevil2002@i113940737:~/projects/GPGPUTasks2025/build$ ./main_aplusb_matrix 1
Found 3 GPUs in 0.098511 sec (OpenCL: 0.079085 sec, Vulkan: 0.019377 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
  Device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15829/15829 Mb.
Using device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.124044 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.055222 10%=0.055347 median=0.055933 90%=0.270335 max=0.270335)
a + b kernel median VRAM bandwidth: 26.8178 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.106561 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.024043 10%=0.024167 median=0.024864 90%=0.132752 max=0.132752)
a + b kernel median VRAM bandwidth: 60.3282 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
  ./main_aplusb_matrix 0
  shell: /usr/bin/bash -e {0}
  env:
    BUILD_TYPE: RelWithDebInfo
    LD_LIBRARY_PATH: /usr/local/cuda/targets/x86_64-linux/lib/stubs:/usr/local/cuda/lib64:
Found 2 GPUs in 0.04413 sec (CUDA: 8.1e-05 sec, OpenCL: 0.019925 sec, Vulkan: 0.024076 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.127167 seconds
a + b matrix kernel times (in seconds) - 10 values (min=1.49623 10%=1.50077 median=1.52419 90%=1.70615 max=1.70615)
a + b kernel median VRAM bandwidth: 0.984132 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.028294 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.110841 10%=0.110858 median=0.111208 90%=0.139669 max=0.139669)
a + b kernel median VRAM bandwidth: 13.4882 GB/s
</pre>

</p></details>