### PR TITLE
Task01 Aldar Antonov HSE

### DIFF
--- a/src/kernels/cu/aplusb_matrix_bad.cu
+++ b/src/kernels/cu/aplusb_matrix_bad.cu
@@ -19,6 +19,12 @@ __global__ void aplusb_matrix_bad(const unsigned int* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+    unsigned long index = x  * height + y;
+    
+    if (x >= width || y >= height || index >= width * height) return;
+    c[index] = a[index] + b[index];
 }
 
 namespace cuda {

--- a/src/kernels/cu/aplusb_matrix_good.cu
+++ b/src/kernels/cu/aplusb_matrix_good.cu
@@ -17,8 +17,16 @@ __global__ void aplusb_matrix_good(const unsigned int* a,
     // т.е. матрица выложена в памяти линейно ряд за рядом
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
-
+    
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x < width && y < height) {
+        size_t index = static_cast<size_t>(y) * width + x;
+        c[index] = a[index] + b[index];
+    }
 }
 
 namespace cuda {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -1,3 +1,4 @@
+#include <cuda_runtime_api.h>
 #include <libbase/stats.h>
 #include <libutils/misc.h>
 
@@ -23,7 +24,7 @@ void run(int argc, char** argv)
     // TODO 100 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 100 после этого реализуйте два кернела - максимально эффективный и максимально неэффктивный вариант сложения матриц - src/kernels/<ваш выбор>/aplusb_matrix_<bad/good>.<ваш выбор>
     // TODO 100 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -43,7 +44,6 @@ void run(int argc, char** argv)
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
     // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
@@ -56,7 +56,8 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
     // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    a_gpu.writeN(as.data(), width * height);
+    b_gpu.writeN(bs.data(), width * height);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
@@ -69,7 +70,7 @@ void run(int argc, char** argv)
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(256, 1, width, height);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
@@ -77,7 +78,7 @@ void run(int argc, char** argv)
             if (context.type() == gpu::Context::TypeOpenCL) {
                 // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
             } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
+                cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, width, height);
             } else if (context.type() == gpu::Context::TypeVulkan) {
                 struct {
                     unsigned int width;
@@ -93,10 +94,15 @@ void run(int argc, char** argv)
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
         // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        double avgTime = stats::avg(times);
+        double totalBytes = 3.0 * width * height * sizeof(unsigned int);
+        double bandwidthGBs = totalBytes / avgTime / 1e9;
+        std::cout << "Average kernel time = " << avgTime << " s" << std::endl;
+        std::cout << "Effective memory bandwidth = " << bandwidthGBs << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -108,9 +114,47 @@ void run(int argc, char** argv)
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        // Запускаем кернел (несколько раз и с замером времени выполнения)
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
+
+            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
+            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+            gpu::WorkSize workSize(64, 4, width, height);
+
+            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
+            // TODO раскомментируйте вызов вашего API и поправьте его
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                cuda::aplusb_matrix_good(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeVulkan) {
+                struct {
+                    unsigned int width;
+                    unsigned int height;
+                } params = { width, height };
+                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
+        double avgTime = stats::avg(times);
+        double totalBytes = 3.0 * width * height * sizeof(unsigned int);
+        double bandwidthGBs = totalBytes / avgTime / 1e9;
+        std::cout << "Average kernel time = " << avgTime << " s" << std::endl;
+        std::cout << "Effective memory bandwidth = " << bandwidthGBs << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), cs.size());
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
 CUDA_VISIBLE_DEVICES=0 ./main_aplusb_matrix 0
Found 8 GPUs in 1.03763 sec (CUDA: 0.251391 sec, OpenCL: 0.151519 sec, Vulkan: 0.634081 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 15837/16004 Mb.
  Device #1: API: Vulkan. GPU. NVIDIA RTX A4000. Nvidia Corporation. Free memory: 16003/16376 Mb.
  Device #2: API: Vulkan. GPU. Quadro RTX 4000. Nvidia Corporation. Free memory: 7785/8192 Mb.
  Device #3: API: Vulkan. GPU. Quadro RTX 4000. Nvidia Corporation. Free memory: 7553/8192 Mb.
  Device #4: API: Vulkan. GPU. Quadro RTX 4000. Nvidia Corporation. Free memory: 7788/8192 Mb.
  Device #5: API: Vulkan. GPU. Quadro RTX 4000. Nvidia Corporation. Free memory: 7788/8192 Mb.
  Device #6: API: Vulkan. GPU. Quadro RTX 4000. Nvidia Corporation. Free memory: 7788/8192 Mb.
  Device #7: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 515838/515838 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 15837/16004 Mb.
Using CUDA API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.052024 10%=0.052047 median=0.05207 90%=0.052387 max=0.052387)
Average kernel time = 0.0520987 s
Effective memory bandwidth = 30.9146 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.004055 10%=0.004059 median=0.004065 90%=0.004339 max=0.004339)
Average kernel time = 0.0040903 s
Effective memory bandwidth = 393.764 GB/s
Segmentation fault (core dumped)
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./main_aplusb_matrix 0
Found 2 GPUs in 0.044227 sec (CUDA: 7.8e-05 sec, OpenCL: 0.020286 sec, Vulkan: 0.023817 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Device AMD EPYC 7763 64-Core Processor                 doesn't support CUDA
Error: Device doesn't support requested API
</pre>

</p></details>