### PR TITLE
Task01 Ахунзянов Ренат SPbU

### DIFF
--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,4 +18,13 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    const unsigned int index = x + y * width;
+    
+    if (index >= width * height)
+        return;
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_good(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,4 +18,13 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    const unsigned int index = x + y * width;
+    
+    if (index >= width * height)
+        return;
+
+    c[index] = a[index] + b[index];
 }

--- a/src/main_aplusb.cpp
+++ b/src/main_aplusb.cpp
@@ -56,12 +56,11 @@ void run(int argc, char** argv)
 
         // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
         gpu::WorkSize workSize(GROUP_SIZE, n);
-        ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
 
         // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
         // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
         if (context.type() == gpu::Context::TypeOpenCL) {
-
+            ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
         } else if (context.type() == gpu::Context::TypeCUDA) {
             cuda::aplusb(workSize, a_gpu, b_gpu, c_gpu, n);
         } else if (context.type() == gpu::Context::TypeVulkan) {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -43,7 +43,7 @@ void run(int argc, char** argv)
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
     // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+    // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
@@ -56,7 +56,9 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
     // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    // rassert(false, 5462345134123);
+    a_gpu.writeN(as.data(), width * height);
+    b_gpu.writeN(bs.data(), width * height);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
@@ -69,13 +71,13 @@ void run(int argc, char** argv)
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(1, GROUP_SIZE, width, height);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
             // TODO раскомментируйте вызов вашего API и поправьте его
             if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+                ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             } else if (context.type() == gpu::Context::TypeCUDA) {
                 // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
             } else if (context.type() == gpu::Context::TypeVulkan) {
@@ -93,10 +95,13 @@ void run(int argc, char** argv)
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
         // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        // rassert(false, 54623414231);
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -108,9 +113,45 @@ void run(int argc, char** argv)
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        // Запускаем кернел (несколько раз и с замером времени выполнения)
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
+
+            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
+            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+            gpu::WorkSize workSize(GROUP_SIZE, 1, width, height);
+
+            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
+            // TODO раскомментируйте вызов вашего API и поправьте его
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
+            } else if (context.type() == gpu::Context::TypeVulkan) {
+                struct {
+                    unsigned int width;
+                    unsigned int height;
+                } params = { width, height };
+                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
+        // rassert(false, 54623414231);
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {


### PR DESCRIPTION
Локальный вывод:
```
Found 1 GPUs in 0.048027 sec (OpenCL: 0.047765 sec, Vulkan: 0.000247 sec)
Available devices:
  Device #0: API: OpenCL. GPU. Apple M2 Pro. Total memory: 10922 Mb.
Using device #0: API: OpenCL. GPU. Apple M2 Pro. Total memory: 10922 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.002047 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.037183 10%=0.038524 median=0.038626 90%=0.042176 max=0.042176)
a + b kernel median VRAM bandwidth: 38.8339 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.000217 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.009467 10%=0.009471 median=0.009488 90%=0.030828 max=0.030828)
a + b kernel median VRAM bandwidth: 158.094 GB/s
```

GitHub CI:
```
Found 2 GPUs in 0.044478 sec (CUDA: 8e-05 sec, OpenCL: 0.02057 sec, Vulkan: 0.023782 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.129367 seconds
a + b matrix kernel times (in seconds) - 10 values (min=1.44203 10%=1.46376 median=1.47267 90%=1.75055 max=1.75055)
a + b kernel median VRAM bandwidth: 1.01856 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.028759 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.110996 10%=0.111 median=0.111428 90%=0.140417 max=0.140417)
a + b kernel median VRAM bandwidth: 13.4616 GB/s
```