### PR TITLE
Task01 Адриан Радюк SPbU

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,64 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    gcc
+    cmake
+    gnumake
+
+    # Google Tests
+    gtest
+    xorg.libX11
+
+    # OpenCL
+    ocl-icd
+
+    # CUDA Toolkit
+    cudaPackages.cudatoolkit
+    cudaPackages.cuda_nvcc
+    cudaPackages.cuda_cccl
+    cudaPackages.cuda_cudart
+
+    git gitRepo gnupg autoconf curl
+    procps gnumake util-linux m4 gperf unzip
+    linuxPackages.nvidia_x11
+    libGLU libGL
+    xorg.libXi xorg.libXmu freeglut
+    xorg.libXext xorg.libX11 xorg.libXv xorg.libXrandr zlib 
+    ncurses5 stdenv.cc binutils
+
+    # Vulkan SDK
+    vulkan-tools
+    vulkan-headers
+    vulkan-loader
+    vulkan-memory-allocator
+    vulkan-validation-layers
+    shaderc
+
+    ninja
+    pkg-config
+    clang-tools
+  ];
+
+  shellHook = with pkgs; ''
+    export CMAKE_EXPORT_COMPILE_COMMANDS=ON
+
+    # OpenCL
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${ocl-icd}/lib
+
+    # CUDA
+    export CUDA_PATH=${cudaPackages.cudatoolkit}
+    export CUDA_HOME=${cudaPackages.cudatoolkit}
+    export PATH=$PATH:${cudaPackages.cuda_nvcc}/bin
+    export CMAKE_CUDA_COMPILER=${cudaPackages.cuda_nvcc}/bin/nvcc
+    export LD_LIBRARY_PATH=${cudaPackages.cudatoolkit}/lib:$LD_LIBRARY_PATH
+    export LD_LIBRARY_PATH=${linuxPackages.nvidia_x11}/lib:${ncurses5}/lib:$LD_LIBRARY_PATH
+
+    # Vulkan
+    export CMAKE_INCLUDE_PATH=$CMAKE_INCLUDE_PATH:${vulkan-memory-allocator}/include
+    export VK_LAYER_PATH=${vulkan-validation-layers}/etc/vulkan/explicit_layer.d
+    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:${vulkan-loader}/lib
+    # disable non gpu Vulkan
+    export VK_ICD_FILENAMES=${linuxPackages.nvidia_x11}/share/vulkan/icd.d/nvidia_icd.x86_64.json
+  '';
+}

--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,4 +18,14 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int index_y = get_global_id(0);
+    const unsigned int index_x = get_global_id(1);
+
+    unsigned int index = index_y * height + index_x;
+
+    if (index >= width * height)
+        return;
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_good(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,4 +18,14 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int index_x = get_global_id(0);
+    const unsigned int index_y = get_global_id(1);
+
+    unsigned int index = index_y * width + index_x;
+
+    if (index >= width * height)
+        return;
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cu/aplusb_matrix_bad.cu
+++ b/src/kernels/cu/aplusb_matrix_bad.cu
@@ -19,6 +19,16 @@ __global__ void aplusb_matrix_bad(const unsigned int* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int index_y = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int index_x = blockIdx.y * blockDim.y + threadIdx.y;
+
+    unsigned int index = index_y * height + index_x;
+
+    if (index >= width * height)
+        return;
+
+    c[index] = a[index] + b[index];
 }
 
 namespace cuda {

--- a/src/kernels/cu/aplusb_matrix_good.cu
+++ b/src/kernels/cu/aplusb_matrix_good.cu
@@ -19,6 +19,16 @@ __global__ void aplusb_matrix_good(const unsigned int* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int index_x = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int index_y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    unsigned int index = index_y * width + index_x;
+
+    if (index >= width * height)
+        return;
+
+    c[index] = a[index] + b[index];
 }
 
 namespace cuda {

--- a/src/kernels/vk/aplusb_matrix_bad.comp
+++ b/src/kernels/vk/aplusb_matrix_bad.comp
@@ -14,7 +14,7 @@ layout (push_constant) uniform PushConstants {
 } params;
 
 // TODO не забудьте тут указать размер рабочей группы:
-layout (local_size_x = 1, local_size_y = 1) in;
+layout (local_size_x = GROUP_SIZE, local_size_y = 1) in;
 void main()
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
@@ -24,4 +24,13 @@ void main()
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+	const uint y = gl_GlobalInvocationID.x;
+	const uint x = gl_GlobalInvocationID.y;
+	uint i = y * params.height + x;
+
+	if (i >= params.width * params.height)
+		return;
+
+	cs[i] = as[i] + bs[i];
 }

--- a/src/kernels/vk/aplusb_matrix_good.comp
+++ b/src/kernels/vk/aplusb_matrix_good.comp
@@ -14,7 +14,7 @@ layout (push_constant) uniform PushConstants {
 } params;
 
 // TODO не забудьте тут указать размер рабочей группы:
-layout (local_size_x = 1, local_size_y = 1) in;
+layout (local_size_x = GROUP_SIZE, local_size_y = 1) in;
 void main()
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
@@ -24,4 +24,13 @@ void main()
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+	const uint x = gl_GlobalInvocationID.x;
+	const uint y = gl_GlobalInvocationID.y;
+	uint i = y * params.width + x;
+
+	if (i >= params.width * params.height)
+		return;
+
+	cs[i] = as[i] + bs[i];
 }

--- a/src/main_aplusb.cpp
+++ b/src/main_aplusb.cpp
@@ -56,12 +56,11 @@ void run(int argc, char** argv)
 
         // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
         gpu::WorkSize workSize(GROUP_SIZE, n);
-        ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
 
         // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
         // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
         if (context.type() == gpu::Context::TypeOpenCL) {
-
+            ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
         } else if (context.type() == gpu::Context::TypeCUDA) {
             cuda::aplusb(workSize, a_gpu, b_gpu, c_gpu, n);
         } else if (context.type() == gpu::Context::TypeVulkan) {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -42,9 +42,6 @@ void run(int argc, char** argv)
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
-    // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
     for (size_t i = 0; i < width * height; ++i) {
@@ -56,7 +53,8 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
     // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    a_gpu.writeN(as.data(), width * height);
+    b_gpu.writeN(bs.data(), width * height);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
@@ -69,21 +67,21 @@ void run(int argc, char** argv)
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(GROUP_SIZE, 1, height, width);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
             // TODO раскомментируйте вызов вашего API и поправьте его
             if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+                ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, height, width);
             } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
+                cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, height, width);
             } else if (context.type() == gpu::Context::TypeVulkan) {
                 struct {
                     unsigned int width;
                     unsigned int height;
-                } params = { width, height };
-                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+                } params = { height, width };
+                vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, b_gpu, c_gpu);
             } else {
                 rassert(false, 4531412341, context.type());
             }
@@ -93,10 +91,12 @@ void run(int argc, char** argv)
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
         // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -108,9 +108,43 @@ void run(int argc, char** argv)
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        // Запускаем кернел (несколько раз и с замером времени выполнения)
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
+
+            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
+            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+            gpu::WorkSize workSize(GROUP_SIZE, 1, width, height);
+
+            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
+            // TODO раскомментируйте вызов вашего API и поправьте его
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                cuda::aplusb_matrix_good(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeVulkan) {
+                struct {
+                    unsigned int width;
+                    unsigned int height;
+                } params = { width, height };
+                vk_aplusb_matrix_good.exec(params, workSize, a_gpu, b_gpu, c_gpu);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {


### PR DESCRIPTION

<details><summary>Local OpenCL</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 1 GPUs in 1.5114 sec (CUDA: 1.46324 sec, OpenCL: 0.009469 sec, Vulkan: 0.038664 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU (CUDA 12080). Free memory: 3691/3779 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU (CUDA 12080). Free memory: 3691/3779 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.011971 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.111498 10%=0.111525 median=0.111578 90%=0.123609 max=0.123609)
a + b kernel median VRAM bandwidth: 13.4435 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.031318 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.008764 10%=0.008776 median=0.008819 90%=0.040301 max=0.040301)
a + b kernel median VRAM bandwidth: 170.087 GB/s
</pre>

</p></details>

<details><summary>Local Vulkan</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 1 GPUs in 1.53932 sec (CUDA: 1.47632 sec, OpenCL: 0.009826 sec, Vulkan: 0.053156 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU (CUDA 12080). Free memory: 3691/3779 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU (CUDA 12080). Free memory: 3691/3779 Mb.
Using Vulkan API...
Debug printf was requested, but validation layers were disabled so debug printf will not work, please enable validation layers with context.setVKValidationLayers(true) after calling context.initVulkan(...)
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.113716 10%=0.11397 median=0.114065 90%=0.145746 max=0.145746)
a + b kernel median VRAM bandwidth: 13.1504 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.009569 10%=0.009585 median=0.009971 90%=0.010134 max=0.010134)
a + b kernel median VRAM bandwidth: 150.436 GB/s
</pre>

</p></details>

<details><summary>Local CUDA</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 1 GPUs in 1.54288 sec (CUDA: 1.47157 sec, OpenCL: 0.03041 sec, Vulkan: 0.040875 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU (CUDA 12080). Free memory: 3691/3779 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU (CUDA 12080). Free memory: 3691/3779 Mb.
Using CUDA API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.112103 10%=0.112127 median=0.112192 90%=0.143881 max=0.143881)
a + b kernel median VRAM bandwidth: 13.3699 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.008803 10%=0.008809 median=0.008829 90%=0.039556 max=0.039556)
a + b kernel median VRAM bandwidth: 169.895 GB/s</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Found 2 GPUs in 0.050778 sec (CUDA: 7.8e-05 sec, OpenCL: 0.020784 sec, Vulkan: 0.029868 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.128688 seconds
a + b matrix kernel times (in seconds) - 10 values (min=1.46473 10%=1.55182 median=1.60919 90%=1.70864 max=1.70864)
a + b kernel median VRAM bandwidth: 0.932144 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.02868 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.111075 10%=0.111214 median=0.11141 90%=0.141287 max=0.141287)
a + b kernel median VRAM bandwidth: 13.4638 GB/s

</p></details>
