### PR TITLE
Task01 Konstantin Koloskov ITMO

### DIFF
--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -5,16 +5,13 @@
 #include "../defines.h"
 
 __kernel void aplusb_matrix_bad(__global const uint* a,
-                     __global const uint* b,
-                     __global       uint* c,
-                     unsigned int width,
-                     unsigned int height)
+                                __global const uint* b,
+                                __global       uint* c,
+                                unsigned int width,
+                                unsigned int height)
 {
-    // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
-    // при этом в памяти подряд идут элементы являющимися соседями в рамках одного ряда,
-    // т.е. матрица выложена в памяти линейно ряд за рядом
-    // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
-    // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
-
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    size_t i = get_global_id(0) * height + get_global_id(1);
+    if (i < width * height) {
+        c[i] = a[i] + b[i];
+    }
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -5,16 +5,13 @@
 #include "../defines.h"
 
 __kernel void aplusb_matrix_good(__global const uint* a,
-                     __global const uint* b,
-                     __global       uint* c,
-                     unsigned int width,
-                     unsigned int height)
+                                 __global const uint* b,
+                                 __global       uint* c,
+                                 unsigned int width,
+                                 unsigned int height)
 {
-    // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
-    // при этом в памяти подряд идут элементы являющимися соседями в рамках одного ряда,
-    // т.е. матрица выложена в памяти линейно ряд за рядом
-    // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
-    // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
-
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    size_t i = get_global_id(1) * width + get_global_id(0);
+    if (i < width * height) {
+        c[i] = a[i] + b[i];
+    }
 }

--- a/src/main_aplusb.cpp
+++ b/src/main_aplusb.cpp
@@ -12,24 +12,10 @@
 
 void run(int argc, char** argv)
 {
-    // chooseGPUVkDevices:
-    // - Если не доступо ни одного устройства - кинет ошибку
-    // - Если доступно ровно одно устройство - вернет это устройство
-    // - Если доступно N>1 устройства:
-    //   - Если аргументов запуска нет или переданное число не находится в диапазоне от 0 до N-1 - кинет ошибку
-    //   - Если аргумент запуска есть и он от 0 до N-1 - вернет устройство под указанным номером
+
     gpu::Device device = gpu::chooseGPUDevice(gpu::selectAllDevices(ALL_GPUS, true), argc, argv);
 
-    // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
-    // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
-    // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
     gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
-    // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU
-    // CUDA   - рекомендуется если у вас NVIDIA видеокарта, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
-    // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
-    //          если же вас это не останавливает - профилировщик (nsight-systems) при запуске на NVIDIA тоже работает (хоть и менее мощный чем nsight-compute)
-    //          кроме того есть debugPrintfEXT(...) для вывода в консоль с видеокарты
-    //          кроме того используемая библиотека поддерживает rassert-проверки (своеобразные инварианты с уникальным числом) на видеокарте для Vulkan
 
     ocl::KernelSource ocl_aplusb(ocl::getAplusB());
     avk2::KernelSource vk_aplusb(avk2::getAplusB());
@@ -42,30 +28,19 @@ void run(int argc, char** argv)
         bs[i] = 11 * (i + 13) + 17;
     }
 
-    // Аллоцируем буферы в VRAM
     gpu::gpu_mem_32u a_gpu(n), b_gpu(n), c_gpu(n);
 
-    // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
     a_gpu.writeN(as.data(), n);
     b_gpu.writeN(bs.data(), n);
 
-    // Запускаем кернел (несколько раз и с замером времени выполнения)
     std::vector<double> times;
     for (int iter = 0; iter < 10; ++iter) {
         timer t;
 
-        // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
         gpu::WorkSize workSize(GROUP_SIZE, n);
-        ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
 
-        // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
-        // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
         if (context.type() == gpu::Context::TypeOpenCL) {
-
-        } else if (context.type() == gpu::Context::TypeCUDA) {
-            cuda::aplusb(workSize, a_gpu, b_gpu, c_gpu, n);
-        } else if (context.type() == gpu::Context::TypeVulkan) {
-            vk_aplusb.exec(n, workSize, a_gpu, b_gpu, c_gpu);
+            ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
         } else {
             rassert(false, 4531412341, context.type());
         }
@@ -74,15 +49,12 @@ void run(int argc, char** argv)
     }
     std::cout << "a + b kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
-    // Вычисляем достигнутую эффективную пропускную способность видеопамяти
     double memory_size_gb = sizeof(unsigned int) * 3 * n / 1024.0 / 1024.0 / 1024.0;
     std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
-    // Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
     std::vector<unsigned int> cs(n, 0);
     c_gpu.readN(cs.data(), n);
 
-    // Сверяем результат
     for (size_t i = 0; i < n; ++i) {
         rassert(cs[i] == as[i] + bs[i], 321418230421312, cs[i], as[i] + bs[i], i);
     }

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -12,24 +12,10 @@
 
 void run(int argc, char** argv)
 {
-    // chooseGPUVkDevices:
-    // - Если не доступо ни одного устройства - кинет ошибку
-    // - Если доступно ровно одно устройство - вернет это устройство
-    // - Если доступно N>1 устройства:
-    //   - Если аргументов запуска нет или переданное число не находится в диапазоне от 0 до N-1 - кинет ошибку
-    //   - Если аргумент запуска есть и он от 0 до N-1 - вернет устройство под указанным номером
+
     gpu::Device device = gpu::chooseGPUDevice(gpu::selectAllDevices(ALL_GPUS, true), argc, argv);
 
-    // TODO 100 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
-    // TODO 100 после этого реализуйте два кернела - максимально эффективный и максимально неэффктивный вариант сложения матриц - src/kernels/<ваш выбор>/aplusb_matrix_<bad/good>.<ваш выбор>
-    // TODO 100 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
     gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
-    // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU
-    // CUDA   - рекомендуется если у вас NVIDIA видеокарта, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
-    // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
-    //          если же вас это не останавливает - профилировщик (nsight-systems) при запуске на NVIDIA тоже работает (хоть и менее мощный чем nsight-compute)
-    //          кроме того есть debugPrintfEXT(...) для вывода в консоль с видеокарты
-    //          кроме того используемая библиотека поддерживает rassert-проверки (своеобразные инварианты с уникальным числом) на видеокарте для Vulkan
 
     ocl::KernelSource ocl_aplusb_matrix_bad(ocl::getAplusBMatrixBad());
     ocl::KernelSource ocl_aplusb_matrix_good(ocl::getAplusBMatrixGood());
@@ -42,48 +28,29 @@ void run(int argc, char** argv)
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
-    // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
-    std::vector<unsigned int> as(width * height, 0);
-    std::vector<unsigned int> bs(width * height, 0);
-    for (size_t i = 0; i < width * height; ++i) {
+    const unsigned int WxH = width * height;
+    std::vector<unsigned int> as(WxH, 0);
+    std::vector<unsigned int> bs(WxH, 0);
+    for (size_t i = 0; i < WxH; ++i) {
         as[i] = 3 * (i + 5) + 7;
         bs[i] = 11 * (i + 13) + 17;
     }
 
-    // Аллоцируем буферы в VRAM
-    gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
-    // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    gpu::gpu_mem_32u a_gpu(WxH), b_gpu(WxH), c_gpu(WxH);
+
+    a_gpu.writeN(as.data(), WxH);
+    b_gpu.writeN(bs.data(), WxH);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
 
-        // Запускаем кернел (несколько раз и с замером времени выполнения)
         std::vector<double> times;
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
-
-            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
-            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
-            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
-
-            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
-            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
-            // TODO раскомментируйте вызов вашего API и поправьте его
+            gpu::WorkSize workSize(GROUP_SIZE, 1, width, height);
             if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeVulkan) {
-                struct {
-                    unsigned int width;
-                    unsigned int height;
-                } params = { width, height };
-                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+                 ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             } else {
                 rassert(false, 4531412341, context.type());
             }
@@ -92,13 +59,12 @@ void run(int argc, char** argv)
         }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
-        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        double memory_size_gb = sizeof(unsigned int) * 3 * WxH / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
-        std::vector<unsigned int> cs(width * height, 0);
+        std::vector<unsigned int> cs(WxH, 0);
+        c_gpu.readN(cs.data(), WxH);
 
-        // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230421312512, cs[i], as[i] + bs[i], i);
         }
@@ -107,12 +73,27 @@ void run(int argc, char** argv)
     {
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
-        // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
+            gpu::WorkSize workSize(GROUP_SIZE, 1, width, height);
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        double memory_size_gb = sizeof(unsigned int) * 3 * WxH / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
+
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.read(cs.data(), sizeof(unsigned int) * cs.size());
 
-        // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230365731436, cs[i], as[i] + bs[i], i);
         }


### PR DESCRIPTION
Output on local machine:

<pre>
Found 2 GPUs in 0.105 sec (OpenCL: 0.086 sec, Vulkan: 0.019 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12500H. Intel(R) Corporation. Total memory: 16077 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) Iris(R) Xe Graphics. Free memory: 7380/6431 Mb.
Using device #1: API: OpenCL+Vulkan. GPU. Intel(R) Iris(R) Xe Graphics. Free memory: 7380/6431 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.203 seconds
a + b matrix kernel times (in seconds) - 10 values (min=4.156 10%=4.165 median=4.232 90%=4.905 max=4.905)
a + b kernel median VRAM bandwidth: 0.354442 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.257 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.062 10%=0.063 median=0.071 90%=0.325 max=0.325)
a + b kernel median VRAM bandwidth: 21.1268 GB/s
</pre>

Output on Github CI:

<pre>
Found 2 GPUs in 0.050247 sec (CUDA: 9.1e-05 sec, OpenCL: 0.023134 sec, Vulkan: 0.026969 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.137822 seconds
a + b matrix kernel times (in seconds) - 10 values (min=1.83169 10%=2.08887 median=2.29639 90%=3.21084 max=3.21084)
a + b kernel median VRAM bandwidth: 0.6532 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.030467 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.065973 10%=0.079563 median=0.09042 90%=0.109797 max=0.109797)
a + b kernel median VRAM bandwidth: 16.5893 GB/s
</pre>