### PR TITLE
Task01 Евгений Акимов HSE SPb

### DIFF
--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -16,5 +16,13 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+
+    if (x >= width || y >= height)
+        return;
+
+    const unsigned int index = x * height + y;
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -16,5 +16,13 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+
+    if (x >= width || y >= height)
+        return;
+
+    const unsigned int index = y * width + x;
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cu/aplusb_matrix_bad.cu
+++ b/src/kernels/cu/aplusb_matrix_bad.cu
@@ -18,7 +18,15 @@ __global__ void aplusb_matrix_bad(const unsigned int* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= width || y >= height)
+        return;
+
+    const unsigned int index = x * height + y;
+
+    c[index] = a[index] + b[index];
 }
 
 namespace cuda {

--- a/src/kernels/cu/aplusb_matrix_good.cu
+++ b/src/kernels/cu/aplusb_matrix_good.cu
@@ -18,7 +18,16 @@ __global__ void aplusb_matrix_good(const unsigned int* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+
+    if (x >= width || y >= height)
+        return;
+
+    const unsigned int index = y * width + x;
+
+    c[index] = a[index] + b[index];
 }
 
 namespace cuda {

--- a/src/kernels/vk/aplusb_matrix_bad.comp
+++ b/src/kernels/vk/aplusb_matrix_bad.comp
@@ -14,7 +14,7 @@ layout (push_constant) uniform PushConstants {
 } params;
 
 // TODO не забудьте тут указать размер рабочей группы:
-layout (local_size_x = 1, local_size_y = 1) in;
+layout (local_size_x = 16, local_size_y = 16) in;
 void main()
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
@@ -23,5 +23,13 @@ void main()
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const uint x = gl_GlobalInvocationID.x;
+    const uint y = gl_GlobalInvocationID.y;
+
+    if (x >= params.width || y >= params.height)
+        return;
+
+    const uint index = x * params.height + y;
+
+    cs[index] = as[index] + bs[index];
 }

--- a/src/kernels/vk/aplusb_matrix_good.comp
+++ b/src/kernels/vk/aplusb_matrix_good.comp
@@ -14,7 +14,7 @@ layout (push_constant) uniform PushConstants {
 } params;
 
 // TODO не забудьте тут указать размер рабочей группы:
-layout (local_size_x = 1, local_size_y = 1) in;
+layout (local_size_x = 16, local_size_y = 16) in;
 void main()
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
@@ -23,5 +23,13 @@ void main()
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const uint x = gl_GlobalInvocationID.x;
+    const uint y = gl_GlobalInvocationID.y;
+
+    if (x >= params.width || y >= params.height)
+        return;
+
+    const uint index = y * params.width + x;
+
+    cs[index] = as[index] + bs[index];
 }

--- a/src/main_aplusb.cpp
+++ b/src/main_aplusb.cpp
@@ -56,12 +56,11 @@ void run(int argc, char** argv)
 
         // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
         gpu::WorkSize workSize(GROUP_SIZE, n);
-        ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
 
         // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
         // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
         if (context.type() == gpu::Context::TypeOpenCL) {
-
+            ocl_aplusb.exec(workSize, a_gpu, b_gpu, c_gpu, n);
         } else if (context.type() == gpu::Context::TypeCUDA) {
             cuda::aplusb(workSize, a_gpu, b_gpu, c_gpu, n);
         } else if (context.type() == gpu::Context::TypeVulkan) {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -42,9 +42,6 @@ void run(int argc, char** argv)
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
-    // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
     for (size_t i = 0; i < width * height; ++i) {
@@ -55,8 +52,9 @@ void run(int argc, char** argv)
     // Аллоцируем буферы в VRAM
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
-    // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
+    a_gpu.writeN(as.data(), width * height);
+    b_gpu.writeN(bs.data(), width * height);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
@@ -67,23 +65,19 @@ void run(int argc, char** argv)
             timer t;
 
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
-            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
-            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(16, 16, width, height);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
-            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
-            // TODO раскомментируйте вызов вашего API и поправьте его
             if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+                ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
+                cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, width, height);
             } else if (context.type() == gpu::Context::TypeVulkan) {
                 struct {
                     unsigned int width;
                     unsigned int height;
                 } params = { width, height };
-                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+                vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, b_gpu, c_gpu);
             } else {
                 rassert(false, 4531412341, context.type());
             }
@@ -92,11 +86,13 @@ void run(int argc, char** argv)
         }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
-        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        // Вычисляем достигнутую эффективную пропускную способность видеопамяти
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b matrix kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+        // Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -107,10 +103,40 @@ void run(int argc, char** argv)
     {
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
-        // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        // Запускаем кернел (несколько раз и с замером времени выполнения)
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+            gpu::WorkSize workSize(16, 16, width, height);
+
+            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                cuda::aplusb_matrix_good(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeVulkan) {
+                struct {
+                    unsigned int width;
+                    unsigned int height;
+                } params = { width, height };
+                vk_aplusb_matrix_good.exec(params, workSize, a_gpu, b_gpu, c_gpu);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        // Вычисляем достигнутую эффективную пропускную способность видеопамяти
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b matrix kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
+
+        // Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {


### PR DESCRIPTION
<details><summary>Локальный вывод (OpenCL)</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 1 GPUs in 0.181 sec (CUDA: 0.021 sec, OpenCL: 0.014 sec, Vulkan: 0.145 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3060 (CUDA 13000). Free memory: 11240/12287 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3060 (CUDA 13000). Free memory: 11240/12287 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.012 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.009 10%=0.009 median=0.009 90%=0.022 max=0.022)
a + b matrix kernel median VRAM bandwidth: 166.667 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.007 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.005 10%=0.005 median=0.005 90%=0.013 max=0.013)
a + b matrix kernel median VRAM bandwidth: 300 GB/s
</pre>

</p></details>

<details><summary>Локальный вывод (Vulkan)</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 1 GPUs in 0.176 sec (CUDA: 0.019 sec, OpenCL: 0.014 sec, Vulkan: 0.142 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3060 (CUDA 13000). Free memory: 11240/12287 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3060 (CUDA 13000). Free memory: 11240/12287 Mb.
Using Vulkan API...
Debug printf was requested, but validation layers were disabled so debug printf will not work, please enable validation
layers with context.setVKValidationLayers(true) after calling context.initVulkan(...)
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.011 10%=0.011 median=0.011 90%=0.014 max=0.014)
a + b matrix kernel median VRAM bandwidth: 136.364 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.007 10%=0.007 median=0.008 90%=0.008 max=0.008)
a + b matrix kernel median VRAM bandwidth: 187.5 GB/s
</pre>

</p></details>

<details><summary>Локальный вывод (CUDA)</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 1 GPUs in 0.164 sec (CUDA: 0.02 sec, OpenCL: 0.016 sec, Vulkan: 0.127 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3060 (CUDA 13000). Free memory: 11240/12287 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3060 (CUDA 13000). Free memory: 11240/12287 Mb.
Using CUDA API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.009 10%=0.009 median=0.009 90%=0.01 max=0.01)
a + b matrix kernel median VRAM bandwidth: 166.667 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.004 10%=0.004 median=0.005 90%=0.007 max=0.007)
a + b matrix kernel median VRAM bandwidth: 300 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_aplusb_matrix
Found 2 GPUs in 0.044432 sec (CUDA: 8e-05 sec, OpenCL: 0.020228 sec, Vulkan: 0.024076 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.130893 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.771972 10%=0.786192 median=0.869643 90%=0.921622 max=0.921622)
a + b matrix kernel median VRAM bandwidth: 1.72485 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.032776 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.141631 10%=0.141973 median=0.142978 90%=0.180012 max=0.180012)
a + b matrix kernel median VRAM bandwidth: 10.4911 GB/s
</pre>

</p></details>