### PR TITLE
Task01 Тимофей Зиненко КодТех (закончил МФТИ)

### DIFF
--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -2,13 +2,13 @@
 #include <libgpu/opencl/cl/clion_defines.cl> // This file helps CLion IDE to know what additional functions exists in OpenCL's extended C99
 #endif
 
-#include "../defines.h"
+#include "src/kernels/defines.h"
 
 __kernel void aplusb_matrix_bad(__global const uint* a,
-                     __global const uint* b,
-                     __global       uint* c,
-                     unsigned int width,
-                     unsigned int height)
+    __global const uint* b,
+    __global uint* c,
+    unsigned int width,
+    unsigned int height)
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
     // при этом в памяти подряд идут элементы являющимися соседями в рамках одного ряда,
@@ -16,5 +16,14 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    // реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int gid = get_global_id(0);
+    if (gid >= width * height) {
+        return;
+    }
+
+    unsigned int row = gid % height;
+    unsigned int col = gid / height;
+    unsigned int index = row * width + col;
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -2,13 +2,13 @@
 #include <libgpu/opencl/cl/clion_defines.cl> // This file helps CLion IDE to know what additional functions exists in OpenCL's extended C99
 #endif
 
-#include "../defines.h"
+#include "src/kernels/defines.h"
 
 __kernel void aplusb_matrix_good(__global const uint* a,
-                     __global const uint* b,
-                     __global       uint* c,
-                     unsigned int width,
-                     unsigned int height)
+    __global const uint* b,
+    __global uint* c,
+    unsigned int width,
+    unsigned int height)
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
     // при этом в памяти подряд идут элементы являющимися соседями в рамках одного ряда,
@@ -16,5 +16,11 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    // реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int index = get_global_id(0);
+    if (index >= width * height) {
+        return;
+    }
+
+    c[index] = a[index] + b[index];
 }

--- a/src/kernels/cu/aplusb_matrix_bad.cu
+++ b/src/kernels/cu/aplusb_matrix_bad.cu
@@ -1,16 +1,16 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
 #include "../defines.h"
 
 __global__ void aplusb_matrix_bad(const unsigned int* a,
-                       const unsigned int* b,
-                             unsigned int* c,
-                             unsigned int  width,
-                             unsigned int  height)
+    const unsigned int* b,
+    unsigned int* c,
+    unsigned int width,
+    unsigned int height)
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
     // при этом в памяти подряд идут элементы являющимися соседями в рамках одного ряда,
@@ -18,12 +18,21 @@ __global__ void aplusb_matrix_bad(const unsigned int* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    // реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int x = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int total_elements = width * height;
+    if (x >= total_elements) {
+        return;
+    }
+    unsigned int row = x % height;
+    unsigned int col = x / height;
+    unsigned int index = row * width + col;
+    c[index] = a[index] + b[index];
 }
 
 namespace cuda {
-void aplusb_matrix_bad(const gpu::WorkSize &workSize,
-            const gpu::gpu_mem_32u &a, const gpu::gpu_mem_32u &b, gpu::gpu_mem_32u &c, unsigned int width, unsigned int height)
+void aplusb_matrix_bad(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32u& a, const gpu::gpu_mem_32u& b, gpu::gpu_mem_32u& c, unsigned int width, unsigned int height)
 {
     gpu::Context context;
     rassert(context.type() == gpu::Context::TypeCUDA, 34523543124312, context.type());

--- a/src/kernels/cu/aplusb_matrix_good.cu
+++ b/src/kernels/cu/aplusb_matrix_good.cu
@@ -1,16 +1,16 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
 #include "../defines.h"
 
 __global__ void aplusb_matrix_good(const unsigned int* a,
-                       const unsigned int* b,
-                             unsigned int* c,
-                             unsigned int  width,
-                             unsigned int  height)
+    const unsigned int* b,
+    unsigned int* c,
+    unsigned int width,
+    unsigned int height)
 {
     // все три массива - линейно выложенные двумерные матрицы размера width (число столбиков) x height (число рядов)
     // при этом в памяти подряд идут элементы являющимися соседями в рамках одного ряда,
@@ -18,12 +18,19 @@ __global__ void aplusb_matrix_good(const unsigned int* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    // реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    unsigned int total_elements = width * height;
+    if (idx >= total_elements) {
+        return;
+    }
+
+    c[idx] = a[idx] + b[idx];
 }
 
 namespace cuda {
-void aplusb_matrix_good(const gpu::WorkSize &workSize,
-            const gpu::gpu_mem_32u &a, const gpu::gpu_mem_32u &b, gpu::gpu_mem_32u &c, unsigned int width, unsigned int height)
+void aplusb_matrix_good(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32u& a, const gpu::gpu_mem_32u& b, gpu::gpu_mem_32u& c, unsigned int width, unsigned int height)
 {
     gpu::Context context;
     rassert(context.type() == gpu::Context::TypeCUDA, 34523543124312, context.type());

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -20,10 +20,13 @@ void run(int argc, char** argv)
     //   - Если аргумент запуска есть и он от 0 до N-1 - вернет устройство под указанным номером
     gpu::Device device = gpu::chooseGPUDevice(gpu::selectAllDevices(ALL_GPUS, true), argc, argv);
 
-    // TODO 100 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
-    // TODO 100 после этого реализуйте два кернела - максимально эффективный и максимально неэффктивный вариант сложения матриц - src/kernels/<ваш выбор>/aplusb_matrix_<bad/good>.<ваш выбор>
-    // TODO 100 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    // 100 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
+    // 100 после этого реализуйте два кернела - максимально эффективный и максимально неэффктивный вариант сложения матриц - src/kernels/<ваш выбор>/aplusb_matrix_<bad/good>.<ваш выбор>
+    // 100 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
+
+    // gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
+
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -42,9 +45,6 @@ void run(int argc, char** argv)
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
-    // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
     for (size_t i = 0; i < width * height; ++i) {
@@ -55,8 +55,9 @@ void run(int argc, char** argv)
     // Аллоцируем буферы в VRAM
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
-    // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    // Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
+    a_gpu.writeN(as.data(), as.size());
+    b_gpu.writeN(bs.data(), bs.size());
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
@@ -68,22 +69,17 @@ void run(int argc, char** argv)
 
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
-            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            // И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+            // gpu::WorkSize workSize(256, 1, width * height, 1);
+            gpu::WorkSize workSize((unsigned int)256, (unsigned int)1, width * height, (unsigned int)1);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
-            // TODO раскомментируйте вызов вашего API и поправьте его
+            // раскомментируйте вызов вашего API и поправьте его
             if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+                ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, (unsigned int)width, (unsigned int)height);
             } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeVulkan) {
-                struct {
-                    unsigned int width;
-                    unsigned int height;
-                } params = { width, height };
-                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+                cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, (unsigned int)width, (unsigned int)height);
             } else {
                 rassert(false, 4531412341, context.type());
             }
@@ -92,11 +88,15 @@ void run(int argc, char** argv)
         }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
-        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        // Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
+        double data_volume_bytes = sizeof(unsigned int) * width * height * 3;
+        double median_time_sec = stats::median(times);
+        double bandwidth_gbs = (data_volume_bytes / median_time_sec) / (1024.0 * 1024.0 * 1024.0);
+        std::cout << "Effective bandwidth: " << bandwidth_gbs << " GB/s" << std::endl;
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+        // Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), cs.size());
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -107,10 +107,33 @@ void run(int argc, char** argv)
     {
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
-        // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        // Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+            gpu::WorkSize workSize(256, 1, width, height);
+
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, (unsigned int)width, (unsigned int)height);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                cuda::aplusb_matrix_good(workSize, a_gpu, b_gpu, c_gpu, (unsigned int)width, (unsigned int)height);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        double data_volume_bytes = 3.0 * width * height * sizeof(unsigned int);
+        double median_time_sec = stats::median(times);
+        double bandwidth_gbs = (data_volume_bytes / median_time_sec) / (1024.0 * 1024.0 * 1024.0);
+        std::cout << "Effective bandwidth: " << bandwidth_gbs << " GB/s" << std::endl;
+
+        // Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), cs.size());
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -128,7 +151,8 @@ int main(int argc, char** argv)
         if (e.what() == DEVICE_NOT_SUPPORT_API) {
             // Возвращаем exit code = 0 чтобы на CI не было красного крестика о неуспешном запуске из-за выбора CUDA API (его нет на процессоре - т.е. в случае CI на GitHub Actions)
             return 0;
-        } if (e.what() == CODE_IS_NOT_IMPLEMENTED) {
+        }
+        if (e.what() == CODE_IS_NOT_IMPLEMENTED) {
             // Возвращаем exit code = 0 чтобы на CI не было красного крестика о неуспешном запуске из-за того что задание еще не выполнено
             return 0;
         } else {


### PR DESCRIPTION
<details><summary>Локальный вывод </summary><p>
контекст OpenCL
<pre>
./main_aplusb_matrix 0
Found 3 GPUs in 0.305507 sec (CUDA: 0.091609 sec, OpenCL: 0.083192 sec, Vulkan: 0.130592 sec)
Available devices:
  Device #0: API: OpenCL. CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 64161 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5598/7785 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 64161/64161 Mb.
Using device #0: API: OpenCL. CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 64161 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.162865 seconds
a + b matrix kernel times (in seconds) - 10 values (min=1.35542 10%=1.35867 median=1.37058 90%=1.68915 max=1.68915)
Effective bandwidth: 1.09443 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.042046 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.013112 10%=0.013342 median=0.01361 90%=0.05807 max=0.05807)
Effective bandwidth: 110.213 GB/s
</pre>

<pre>
./main_aplusb_matrix 1
Found 3 GPUs in 0.251924 sec (CUDA: 0.062138 sec, OpenCL: 0.08483 sec, Vulkan: 0.104871 sec)
Available devices:
  Device #0: API: OpenCL. CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 64161 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5440/7785 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 64161/64161 Mb.
Using device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5443/7785 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.072328 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.024969 10%=0.024998 median=0.025277 90%=0.105189 max=0.105189)
Effective bandwidth: 59.3425 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.056907 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.001217 10%=0.001218 median=0.001219 90%=0.058331 max=0.058331)
Effective bandwidth: 1230.52 GB/s
</pre>

контекст    CUDA
<pre>
./main_aplusb_matrix 1
Found 3 GPUs in 0.268624 sec (CUDA: 0.061418 sec, OpenCL: 0.083034 sec, Vulkan: 0.124084 sec)
Available devices:
  Device #0: API: OpenCL. CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 64161 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5495/7785 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 64161/64161 Mb.
Using device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5495/7785 Mb.
Using CUDA API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.023099 10%=0.023101 median=0.027178 90%=0.049925 max=0.049925)
Effective bandwidth: 55.1917 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 10 values (min=0.001206 10%=0.001207 median=0.001208 90%=0.009289 max=0.009289)
Effective bandwidth: 1241.72 GB/s
</pre>