### PR TITLE
Task02 Вячеслав Григорович ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -12,8 +12,36 @@ __kernel void mandelbrot(__global float* results,
                      float sizeX, float sizeY,
                      unsigned int iters, unsigned int isSmoothing)
 {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    if (i >= width || j >= height) {
+        return;
+    }
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    unsigned int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -9,11 +9,19 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        __global       uint* sum,
                                                        const unsigned int n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    local_data[local_index] = index < n ? a[index]: 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint local_sum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        atomic_add(sum, local_sum);
+    }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -11,11 +11,19 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                      __global       uint* b,
                                             unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    local_data[local_index] = index < n ? a[index]: 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint local_sum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        b[get_group_id(0)] = local_sum;
+    }
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,8 +121,7 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    ocl_mandelbrot.exec(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height), gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
daredevil2002@i113940737:~/projects/GPGPUTasks2025/build$ ./main_mandelbrot 0
Found 3 GPUs in 0.0565488 sec (OpenCL: 0.0402426 sec, Vulkan: 0.0162807 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
  Device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15829/15829 Mb.
Using device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.82801 10%=2.82801 median=2.82801 90%=2.82801 max=2.82801)
Mandelbrot effective algorithm GFlops: 3.53605 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x20 threads
algorithm times (in seconds) - 10 values (min=0.334302 10%=0.334535 median=0.356567 90%=0.364833 max=0.364833)
Mandelbrot effective algorithm GFlops: 28.0452 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.231448 seconds
algorithm times (in seconds) - 10 values (min=0.0358195 10%=0.0359274 median=0.0372737 90%=0.269235 max=0.269235)
Mandelbrot effective algorithm GFlops: 268.286 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

daredevil2002@i113940737:~/projects/GPGPUTasks2025/build$ ./main_mandelbrot 1
Found 3 GPUs in 0.0570391 sec (OpenCL: 0.0418911 sec, Vulkan: 0.0151228 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
  Device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15829/15829 Mb.
Using device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.82802 10%=2.82802 median=2.82802 90%=2.82802 max=2.82802)
Mandelbrot effective algorithm GFlops: 3.53604 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x20 threads
algorithm times (in seconds) - 10 values (min=0.306728 10%=0.339416 median=0.347927 90%=0.372934 max=0.372934)
Mandelbrot effective algorithm GFlops: 28.7417 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.113742 seconds
algorithm times (in seconds) - 10 values (min=0.0131442 10%=0.0131492 median=0.013351 90%=0.130677 max=0.130677)
Mandelbrot effective algorithm GFlops: 749.008 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

daredevil2002@i113940737:~/projects/GPGPUTasks2025/build$ ./main_sum 0
Found 3 GPUs in 0.0605612 sec (OpenCL: 0.0452563 sec, Vulkan: 0.0152767 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
  Device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15829/15829 Mb.
Using device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
Using OpenCL API...
CPU RAM -> GPU VRAM times (in seconds) - 10 values (min=0.0137532 10%=0.0137984 median=0.013856 90%=0.0240115 max=0.0240115)
CPU RAM -> GPU VRAM median VRAM bandwidth: 26.8858 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.111979 10%=0.115483 median=0.128109 90%=0.137069 max=0.137069)
sum median effective algorithm bandwidth: 2.9079 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0106998 10%=0.0110848 median=0.0117681 90%=0.0147801 max=0.0147801)
sum median effective algorithm bandwidth: 31.6557 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.0739469 seconds
algorithm times (in seconds) - 10 values (min=1.6095 10%=1.61119 median=1.6139 90%=1.6889 max=1.6889)
sum median effective algorithm bandwidth: 0.230826 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0257989 seconds
algorithm times (in seconds) - 10 values (min=0.811428 10%=0.814559 median=0.827271 90%=0.841648 max=0.841648)
sum median effective algorithm bandwidth: 0.450311 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0338133 seconds
algorithm times (in seconds) - 10 values (min=0.0109554 10%=0.0110695 median=0.0123645 90%=0.0462986 max=0.0462986)
sum median effective algorithm bandwidth: 30.1288 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0229608 seconds
algorithm times (in seconds) - 10 values (min=0.0105082 10%=0.0107596 median=0.0120079 90%=0.0337266 max=0.0337266)
sum median effective algorithm bandwidth: 31.0237 GB/s

daredevil2002@i113940737:~/projects/GPGPUTasks2025/build$ ./main_sum 1
Found 3 GPUs in 0.0625686 sec (OpenCL: 0.0474576 sec, Vulkan: 0.015086 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13700H. Intel(R) Corporation. Total memory: 15829 Mb.
  Device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15829/15829 Mb.
Using device #1: API: OpenCL. GPU. Intel(R) Graphics [0xa7a0]. Total memory: 12976 Mb.
Using OpenCL API...
CPU RAM -> GPU VRAM times (in seconds) - 10 values (min=0.0162109 10%=0.016226 median=0.0162483 90%=0.0897129 max=0.0897129)
CPU RAM -> GPU VRAM median VRAM bandwidth: 22.9273 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0963708 10%=0.105032 median=0.109611 90%=0.118571 max=0.118571)
sum median effective algorithm bandwidth: 3.39865 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0122993 10%=0.012492 median=0.0145913 90%=0.0207493 max=0.0207493)
sum median effective algorithm bandwidth: 25.531 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.116951 seconds
algorithm times (in seconds) - 10 values (min=0.00635261 10%=0.0064035 median=0.00662466 90%=0.133726 max=0.133726)
sum median effective algorithm bandwidth: 56.2337 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0981461 seconds
algorithm times (in seconds) - 10 values (min=0.00562239 10%=0.00581881 median=0.005956 90%=0.104904 max=0.104904)
sum median effective algorithm bandwidth: 62.5468 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0974474 seconds
algorithm times (in seconds) - 10 values (min=0.00761902 10%=0.00774861 median=0.00787404 90%=0.105621 max=0.105621)
sum median effective algorithm bandwidth: 47.311 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.1054 seconds
algorithm times (in seconds) - 10 values (min=0.00808176 10%=0.00816772 median=0.00875662 90%=0.114886 max=0.114886)
sum median effective algorithm bandwidth: 42.5426 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
  ./main_mandelbrot 0
  shell: /usr/bin/bash -e {0}
  env:
    BUILD_TYPE: RelWithDebInfo
    LD_LIBRARY_PATH: /usr/local/cuda/targets/x86_64-linux/lib/stubs:/usr/local/cuda/lib64:
Found 2 GPUs in 0.0434969 sec (CUDA: 7.5972e-05 sec, OpenCL: 0.0193733 sec, Vulkan: 0.0240067 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00095 10%=2.00095 median=2.00095 90%=2.00095 max=2.00095)
Mandelbrot effective algorithm GFlops: 4.99762 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.606907 10%=0.607049 median=0.6095 90%=0.723351 max=0.723351)
Mandelbrot effective algorithm GFlops: 16.4069 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.147609 seconds
algorithm times (in seconds) - 10 values (min=0.149488 10%=0.149526 median=0.149591 90%=0.299315 max=0.299315)
Mandelbrot effective algorithm GFlops: 66.8487 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

  ./main_sum 0
  shell: /usr/bin/bash -e {0}
  env:
    BUILD_TYPE: RelWithDebInfo
    LD_LIBRARY_PATH: /usr/local/cuda/targets/x86_64-linux/lib/stubs:/usr/local/cuda/lib64:
Found 2 GPUs in 0.0449072 sec (CUDA: 7.9389e-05 sec, OpenCL: 0.0200315 sec, Vulkan: 0.0247503 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
CPU RAM -> GPU VRAM times (in seconds) - 10 values (min=0.0215904 10%=0.0216079 median=0.0218755 90%=0.0255446 max=0.0255446)
CPU RAM -> GPU VRAM median VRAM bandwidth: 17.0295 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0333366 10%=0.0334464 median=0.0335319 90%=0.0368636 max=0.0368636)
sum median effective algorithm bandwidth: 11.1097 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0235592 10%=0.0240574 median=0.0255439 90%=0.0296723 max=0.0296723)
sum median effective algorithm bandwidth: 14.5839 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.110668 seconds
algorithm times (in seconds) - 10 values (min=1.54372 10%=1.54398 median=1.55179 90%=1.65496 max=1.65496)
sum median effective algorithm bandwidth: 0.240064 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0288779 seconds
algorithm times (in seconds) - 10 values (min=0.772844 10%=0.773031 median=0.773617 90%=0.802724 max=0.802724)
sum median effective algorithm bandwidth: 0.481542 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0459963 seconds
algorithm times (in seconds) - 10 values (min=0.0568551 10%=0.0569685 median=0.0570741 90%=0.103471 max=0.103471)
sum median effective algorithm bandwidth: 6.52711 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0365198 seconds
algorithm times (in seconds) - 10 values (min=0.0653004 10%=0.0653613 median=0.0655742 90%=0.103139 max=0.103139)
sum median effective algorithm bandwidth: 5.68103 GB/s
</pre>

</p></details>