### PR TITLE
Task02 Иван Шиляев HSE

### DIFF
--- a/src/kernels/cu/mandelbrot.cu
+++ b/src/kernels/cu/mandelbrot.cu
@@ -16,7 +16,31 @@ __global__ void mandelbrot(float* results,
     const unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }
 
 namespace cuda {

--- a/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
+++ b/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
@@ -11,13 +11,29 @@ __global__ void sum_03_local_memory_atomic_per_workgroup(
     unsigned int* sum,
     unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
+    const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n / LOAD_K_VALUES_PER_ITEM) {
+        unsigned int my_sum = 0;
+        for (unsigned int i = 0; i < LOAD_K_VALUES_PER_ITEM; ++i) {
+            my_sum += a[i * (n/LOAD_K_VALUES_PER_ITEM) + index];
+        }
+        local_data[local_index] = my_sum;
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    __syncthreads();
+
+    if (local_index == 0) {
+        unsigned int my_sum = 0;
+        for (unsigned int i = 0; i < GROUP_SIZE; ++i) {
+            my_sum += local_data[i];
+        }
+        atomicAdd(sum, my_sum);
+    }
 }
 
 namespace cuda {

--- a/src/kernels/cu/sum_04_local_reduction.cu
+++ b/src/kernels/cu/sum_04_local_reduction.cu
@@ -13,13 +13,25 @@ __global__ void sum_04_local_reduction(
     unsigned int* b,
     unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
+    const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    __syncthreads();
+
+    if (local_index == 0) {
+        unsigned int my_sum = 0;
+        for (unsigned int i = 0; i < GROUP_SIZE; ++i) {
+            my_sum += local_data[i];
+        }
+        b[index / GROUP_SIZE] = my_sum;
+    }
 }
 
 namespace cuda {

--- a/src/kernels/vk/aplusb.comp
+++ b/src/kernels/vk/aplusb.comp
@@ -29,9 +29,9 @@ void main()
 		// но он может быть включен для локальной разработки и в Release - см. common.vk
 		// (обратите внимание что common.vk так же требует необходимое расширение: #extension GL_EXT_debug_printf : enable)
 		// Необзодимо чтобы validation layers были включены, иначе debugPrintfEXT не заработает
-		#if DEBUG_PRINTF_EXT_ENABLED
-		printf("Vulkan debugPrintfEXT test in aplusb.comp kernel! a[index]=%d b[index]=%d \n", a[index], b[index]);
-		#endif
+		//#if DEBUG_PRINTF_EXT_ENABLED
+		//printf("Vulkan debugPrintfEXT test in aplusb.comp kernel! a[index]=%d b[index]=%d \n", as[index], bs[index]);
+		//#endif
 	}
 
 	// rassert-ы - это способ легко проверить инвариант, если вдруг он будет нарушен - в консоль будет напечатан код этого инварианта

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -58,7 +58,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -86,10 +86,6 @@ void run(int argc, char** argv)
     float sizeY = sizeX * height / width;
 
     image32f cpu_results;
-
-    ocl::KernelSource ocl_mandelbrot(ocl::getMandelbrot());
-
-    avk2::KernelSource vk_mandelbrot(avk2::getMandelbrot());
 
     // Аллоцируем буфер в VRAM
     gpu::gpu_mem_32f gpu_results(width * height);
@@ -119,27 +115,10 @@ void run(int argc, char** argv)
                 if (iter == 0) std::cout << "OpenMP threads: x" << getOpenMPThreadsCount() << " threads" << std::endl;
                 cpu::mandelbrot(current_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing, true);
             } else if (algorithm == "GPU") {
-                // _______________________________OpenCL_____________________________________________
-                if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
-                    // _______________________________CUDA___________________________________________
-                } else if (context.type() == gpu::Context::TypeCUDA) {
-                    // TODO cuda::mandelbrot(..);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
-                    // _______________________________Vulkan_________________________________________
-                } else if (context.type() == gpu::Context::TypeVulkan) {
-                    typedef unsigned int uint;
-                    struct {
-                        uint width; uint height;
-                       float fromX; float fromY;
-                       float sizeX; float sizeY;
-                        uint iters; uint isSmoothing;
-                    } params = { width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing };
-                    // TODO vk_mandelbrot.exec(params, ...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                // _______________________________CUDA___________________________________________
+                if (context.type() == gpu::Context::TypeCUDA) {
+                    gpu::WorkSize workSize(8, 32, width, height);
+                    cuda::mandelbrot(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
                 } else {
                     rassert(false, 546345243, context.type());
                 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -37,23 +37,13 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
     //          если же вас это не останавливает - профилировщик (nsight-systems) при запуске на NVIDIA тоже работает (хоть и менее мощный чем nsight-compute)
     //          кроме того есть debugPrintfEXT(...) для вывода в консоль с видеокарты
     //          кроме того используемая библиотека поддерживает rassert-проверки (своеобразные инварианты с уникальным числом) на видеокарте для Vulkan
-
-    ocl::KernelSource ocl_sum01Atomics(ocl::getSum01Atomics());
-    ocl::KernelSource ocl_sum02AtomicsLoadK(ocl::getSum02AtomicsLoadK());
-    ocl::KernelSource ocl_sum03LocalMemoryAtomicPerWorkgroup(ocl::getSum03LocalMemoryAtomicPerWorkgroup());
-    ocl::KernelSource ocl_sum04LocalReduction(ocl::getSum04LocalReduction());
-
-    avk2::KernelSource vk_sum01Atomics(avk2::getSum01Atomics());
-    avk2::KernelSource vk_sum02AtomicsLoadK(avk2::getSum02AtomicsLoadK());
-    avk2::KernelSource vk_sum03LocalMemoryAtomicPerWorkgroup(avk2::getSum03LocalMemoryAtomicPerWorkgroup());
-    avk2::KernelSource vk_sum04LocalReduction(avk2::getSum04LocalReduction());
 
     unsigned int n = 100 * 1000 * 1000;
     rassert(n % LOAD_K_VALUES_PER_ITEM == 0, 4356345432524); // for simplicity
@@ -72,10 +62,23 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u reduction_buffer2_gpu(div_ceil(n, (unsigned int)GROUP_SIZE));
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    input_gpu.writeN(values.data(), n);
     // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
     // TODO 2) сделайте замер хотя бы три раза
     // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+
+    std::vector<double> pci_times;
+    for (int iter = 0; iter < 10; ++iter) {
+        timer t;
+
+        input_gpu.writeN(values.data(), n);
+
+        pci_times.push_back(t.elapsed());
+    }
+
+    std::cout << "GPU write times (in seconds) - " << stats::valuesStatsLine(pci_times) << std::endl;
+
+    double memory_size_gb = sizeof(unsigned int) * n / 1024.0 / 1024.0 / 1024.0;
+    std::cout << "GPU median write time: " << memory_size_gb / stats::median(pci_times) << " GB/s" << std::endl;
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -102,27 +105,8 @@ void run(int argc, char** argv)
             } else if (algorithm == "CPU with OpenMP") {
                 gpu_sum = cpu::sumOpenMP(values.data(), n);
             } else {
-                // _______________________________OpenCL_____________________________________________
-                if (context.type() == gpu::Context::TypeOpenCL) {
-                    if (algorithm == "01 atomicAdd from each workItem") {
-                        sum_accum_gpu.fill(0);
-                        ocl_sum01Atomics.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "02 atomicAdd but each workItem loads K values") {
-                        sum_accum_gpu.fill(0);
-                        ocl_sum02AtomicsLoadK.exec(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else if (algorithm == "04 local reduction") {
-                        // TODO ocl_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else {
-                        rassert(false, 652345234321, algorithm, algorithm_index);
-                    }
-                    // _______________________________CUDA___________________________________________
-                } else if (context.type() == gpu::Context::TypeCUDA) {
+                // _______________________________CUDA___________________________________________
+                if (context.type() == gpu::Context::TypeCUDA) {
                     if (algorithm == "01 atomicAdd from each workItem") {
                         sum_accum_gpu.fill(0);
                         cuda::sum_01_atomics(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
@@ -132,30 +116,31 @@ void run(int argc, char** argv)
                         cuda::sum_02_atomics_load_k(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO cuda::sum_03_local_memory_atomic_per_workgroup(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else if (algorithm == "04 local reduction") {
-                        // TODO cuda::sum_04_local_reduction(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else {
-                        rassert(false, 652345234321, algorithm, algorithm_index);
-                    }
-                    // _______________________________Vulkan_________________________________________
-                } else if (context.type() == gpu::Context::TypeVulkan) {
-                    if (algorithm == "01 atomicAdd from each workItem") {
                         sum_accum_gpu.fill(0);
-                        vk_sum01Atomics.exec(n, gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu);
+                        cuda::sum_03_local_memory_atomic_per_workgroup(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "02 atomicAdd but each workItem loads K values") {
-                        sum_accum_gpu.fill(0);
-                        vk_sum02AtomicsLoadK.exec(n, gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO vk_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO vk_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        unsigned int result_size = n;
+                        for (unsigned int i = 0; result_size > 1; i++) {
+                            if (i == 0) {
+                                cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, result_size), input_gpu, reduction_buffer1_gpu, result_size);
+                            } else if (i % 2 == 1) {
+                                cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, result_size), reduction_buffer1_gpu, reduction_buffer2_gpu, result_size);
+                            } else if (i % 2 == 0) {
+                                cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, result_size), reduction_buffer2_gpu, reduction_buffer1_gpu, result_size);
+                            }
+
+                            result_size = div_ceil(result_size, (unsigned int)GROUP_SIZE);
+                            if (result_size <= 1) {
+                                if (i % 2 == 0) {
+                                    reduction_buffer1_gpu.readN(&gpu_sum, 1);
+                                } else {
+                                    reduction_buffer2_gpu.readN(&gpu_sum, 1);
+                                }
+                                break;
+                            }
+                        }
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 3 GPUs in 0.244904 sec (CUDA: 0.0194138 sec, OpenCL: 0.108092 sec, Vulkan: 0.116809 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i7-12650H. Intel(R) Corporation. Total memory: 16004 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) UHD Graphics. Free memory: 7346/6401 Mb.
  Device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU (CUDA 13000). Free memory: 3301/4095 Mb.
Using device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU (CUDA 13000). Free memory: 3301/4095 M
b.
Using CUDA API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=3.22264 10%=3.22264 median=3.22264 90%=3.22264 max=3.22264)
Mandelbrot effective algorithm GFlops: 3.10305 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x16 threads
algorithm times (in seconds) - 10 values (min=0.396815 10%=0.412249 median=0.419976 90%=0.445079 max=0.445079)
Mandelbrot effective algorithm GFlops: 23.8109 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
algorithm times (in seconds) - 10 values (min=0.0032262 10%=0.0032486 median=0.0233858 90%=0.0273208 max=0.0273208)
Mandelbrot effective algorithm GFlops: 427.61 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 3 GPUs in 0.22662 sec (CUDA: 0.0191064 sec, OpenCL: 0.10522 sec, Vulkan: 0.101586 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i7-12650H. Intel(R) Corporation. Total memory: 16004 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) UHD Graphics. Free memory: 7346/6401 Mb.
  Device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU (CUDA 13000). Free memory: 3301/4095 Mb.
Using device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU (CUDA 13000). Free memory: 3301/4095 M
b.
Using CUDA API...
GPU write times (in seconds) - 10 values (min=0.044841 10%=0.0454608 median=0.0476317 90%=0.0571652 max=0.0571652)
GPU median write time: 7.82103 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0646319 10%=0.0648218 median=0.0676482 90%=0.0944458 max=0.0944458)
sum median effective algorithm bandwidth: 5.50686 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0146372 10%=0.0149431 median=0.0155571 90%=0.0199512 max=0.0199512)
sum median effective algorithm bandwidth: 23.9459 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
algorithm times (in seconds) - 10 values (min=0.0026481 10%=0.0026548 median=0.0027187 90%=0.0089085 max=0.0089085)
sum median effective algorithm bandwidth: 137.025 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
algorithm times (in seconds) - 10 values (min=0.0021656 10%=0.0021958 median=0.0022553 90%=0.0035419 max=0.0035419)
sum median effective algorithm bandwidth: 165.179 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
algorithm times (in seconds) - 10 values (min=0.0022382 10%=0.0022431 median=0.0022823 90%=0.0048896 max=0.0048896)
sum median effective algorithm bandwidth: 163.225 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
algorithm times (in seconds) - 10 values (min=0.003689 10%=0.0037284 median=0.0037952 90%=0.0818366 max=0.0818366)
sum median effective algorithm bandwidth: 98.1579 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
=== main_mandelbrot stdout ===
Found 1 GPUs in 0.308807 sec (CUDA: 0.12428 sec, OpenCL: 0.0279285 sec, Vulkan: 0.156543 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. Tesla T4 (CUDA 12020). Free memory: 14822/14930 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. Tesla T4 (CUDA 12020). Free memory: 14822/14930 Mb.
Using CUDA API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.86945 10%=2.86945 median=2.86945 90%=2.86945 max=2.86945)
Mandelbrot effective algorithm GFlops: 3.48499 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.888099 10%=0.891047 median=0.894002 90%=0.899817 max=0.899817)
Mandelbrot effective algorithm GFlops: 11.1857 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
algorithm times (in seconds) - 10 values (min=0.00462616 10%=0.00462672 median=0.00463121 90%=0.00479121 max=0.00479121)
Mandelbrot effective algorithm GFlops: 2159.26 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%
=== main_sum stdout ===

Found 1 GPUs in 0.28568 sec (CUDA: 0.126174 sec, OpenCL: 0.0282621 sec, Vulkan: 0.131186 sec)

Available devices:

Device #0: API: CUDA+OpenCL+Vulkan. GPU. Tesla T4 (CUDA 12020). Free memory: 14822/14930 Mb.

Using device #0: API: CUDA+OpenCL+Vulkan. GPU. Tesla T4 (CUDA 12020). Free memory: 14822/14930 Mb.

Using CUDA API...

GPU write times (in seconds) - 10 values (min=0.0394796 10%=0.0395196 median=0.0400081 90%=0.0413044 max=0.0413044)

GPU median write time: 9.31135 GB/s



Evaluating algorithm #1/6: CPU

algorithm times (in seconds) - 10 values (min=0.0319104 10%=0.0319596 median=0.0325185 90%=0.0328726 max=0.0328726)

sum median effective algorithm bandwidth: 11.4559 GB/s



Evaluating algorithm #2/6: CPU with OpenMP

algorithm times (in seconds) - 10 values (min=0.0146676 10%=0.0146989 median=0.0148423 90%=0.0151485 max=0.0151485)

sum median effective algorithm bandwidth: 25.0991 GB/s



Evaluating algorithm #3/6: 01 atomicAdd from each workItem

algorithm times (in seconds) - 10 values (min=0.00274575 10%=0.00274601 median=0.00274665 90%=0.00290114 max=0.00290114)

sum median effective algorithm bandwidth: 135.631 GB/s



Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values

algorithm times (in seconds) - 10 values (min=0.00145679 10%=0.00145699 median=0.00145756 90%=0.00158916 max=0.00158916)

sum median effective algorithm bandwidth: 255.585 GB/s



Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread

algorithm times (in seconds) - 10 values (min=0.0014485 10%=0.0014494 median=0.00145064 90%=0.001583 max=0.001583)

sum median effective algorithm bandwidth: 256.804 GB/s



Evaluating algorithm #6/6: 04 local reduction

algorithm times (in seconds) - 10 values (min=0.00397578 10%=0.00397904 median=0.00398186 90%=0.00410863 max=0.00410863)

sum median effective algorithm bandwidth: 93.5566 GB/s
...
</pre>

</p></details>