### PR TITLE
Task01 Егор Федосеев ITMO

### DIFF
--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+// __attribute__((reqd_work_group_size(GROUP_SIZE, 16, 16)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,4 +18,19 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int x = get_global_id(0) * 256;
+    const unsigned int local_row = get_local_id(1);
+    const unsigned int y = get_global_id(1) * 256 + local_row;
+    if (x >= width || y >= height) {
+        return;
+    }
+    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id1: %d\n", x, y, get_global_id(0), get_global_id(1), local_row);
+    // printf("global_size0: %d   global_size1: %d\n", get_global_size(0), get_global_size(1));
+    // printf("local_size0: %d   local_size1: %d\n", get_local_size(0), get_local_size(1));
+    const unsigned int xBound = min(x + 256, width);
+    // get_global_offset()
+    for (; x < xBound; ++x) {
+        int idx = y * width + x;
+        c[idx] = a[idx] + b[idx];
+    }
 }

--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-// __attribute__((reqd_work_group_size(GROUP_SIZE, 16, 16)))
+__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -19,22 +19,13 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
     unsigned int x = get_global_id(0) * 256;
-    // const unsigned int local_row = get_local_id(1);
     const unsigned int y = get_global_id(1);
     if (x >= width || y >= height) {
         return;
     }
-    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id0: %d   local_id1: %d\n", 
-    //     x, y, get_global_id(0), get_global_id(1), get_local_id(0), local_row);
-    // printf("global_size0: %d   global_size1: %d\n", get_global_size(0), get_global_size(1));
-    // printf("local_size0: %d   local_size1: %d\n", get_local_size(0), get_local_size(1));
     const unsigned int xBound = min(x + 256, width);
-    // get_global_offset()
-    // printf("moving right\n");
     for (; x < xBound; ++x) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
-        // printf("x: %d  y: %d  idx: %d  a[idx]: %d  b[idx]: %d  c[idx]: %d\n", 
-        //     x, y, idx, a[idx], b[idx], c[idx]);
     }
 }

--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
+__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,15 +17,14 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
-
-    unsigned int y = get_global_id(1) * 256;
-    const unsigned int x = get_global_id(0);
+    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int x = get_global_id(0) * 256;
+    const unsigned int y = get_global_id(1);
     if (x >= width || y >= height) {
         return;
     }
-    const unsigned int yBound = min(y + 256, height);
-    for (; y < yBound; ++y) {
+    const unsigned int xBound = min(x + 256, width);
+    for (; x < xBound; ++x) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
     }

--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -19,18 +19,22 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
     unsigned int x = get_global_id(0) * 256;
-    const unsigned int local_row = get_local_id(1);
-    const unsigned int y = get_global_id(1) * 256 + local_row;
+    // const unsigned int local_row = get_local_id(1);
+    const unsigned int y = get_global_id(1);
     if (x >= width || y >= height) {
         return;
     }
-    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id1: %d\n", x, y, get_global_id(0), get_global_id(1), local_row);
+    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id0: %d   local_id1: %d\n", 
+    //     x, y, get_global_id(0), get_global_id(1), get_local_id(0), local_row);
     // printf("global_size0: %d   global_size1: %d\n", get_global_size(0), get_global_size(1));
     // printf("local_size0: %d   local_size1: %d\n", get_local_size(0), get_local_size(1));
     const unsigned int xBound = min(x + 256, width);
     // get_global_offset()
+    // printf("moving right\n");
     for (; x < xBound; ++x) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
+        // printf("x: %d  y: %d  idx: %d  a[idx]: %d  b[idx]: %d  c[idx]: %d\n", 
+        //     x, y, idx, a[idx], b[idx], c[idx]);
     }
 }

--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_bad(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,14 +17,15 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
-    unsigned int x = get_global_id(0) * 256;
-    const unsigned int y = get_global_id(1);
+    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    unsigned int y = get_global_id(1) * 256;
+    const unsigned int x = get_global_id(0);
     if (x >= width || y >= height) {
         return;
     }
-    const unsigned int xBound = min(x + 256, width);
-    for (; x < xBound; ++x) {
+    const unsigned int yBound = min(y + 256, height);
+    for (; y < yBound; ++y) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
     }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -17,4 +17,20 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    const unsigned int y = get_global_id(1) * 256;
+    const unsigned int local_col = get_local_id(0);
+    const unsigned int x = get_global_id(1) * 256 + local_col;
+    if (x >= width || y >= height) {
+        return;
+    }
+    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id1: %d\n", x, y, get_global_id(0), get_global_id(1), local_row);
+    // printf("global_size0: %d   global_size1: %d\n", get_global_size(0), get_global_size(1));
+    // printf("local_size0: %d   local_size1: %d\n", get_local_size(0), get_local_size(1));
+    const unsigned int yBound = min(y + 256, width);
+    // get_global_offset()
+    for (; y < yBound; ++y) {
+        int idx = y * width + x;
+        c[idx] = a[idx] + b[idx];
+    }
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -18,19 +18,23 @@ __kernel void aplusb_matrix_good(__global const uint* a,
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
 
-    const unsigned int y = get_global_id(1) * 256;
-    const unsigned int local_col = get_local_id(0);
-    const unsigned int x = get_global_id(1) * 256 + local_col;
+    unsigned int y = get_global_id(1) * 256;
+    // const unsigned int local_row = get_local_id(1);
+    const unsigned int x = get_global_id(0);
     if (x >= width || y >= height) {
         return;
     }
-    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id1: %d\n", x, y, get_global_id(0), get_global_id(1), local_row);
+    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id0: %d   local_id1: %d\n", 
+    //     x, y, get_global_id(0), get_global_id(1), get_local_id(0), local_row);
     // printf("global_size0: %d   global_size1: %d\n", get_global_size(0), get_global_size(1));
     // printf("local_size0: %d   local_size1: %d\n", get_local_size(0), get_local_size(1));
-    const unsigned int yBound = min(y + 256, width);
+    const unsigned int yBound = min(y + 256, height);
     // get_global_offset()
+    // printf("moving down\n");
     for (; y < yBound; ++y) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
+        // printf("x: %d  y: %d  idx: %d  a[idx]: %d  b[idx]: %d  c[idx]: %d\n", 
+        //     x, y, idx, a[idx], b[idx], c[idx]);
     }
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -4,6 +4,7 @@
 
 #include "../defines.h"
 
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_good(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -19,22 +20,13 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
 
     unsigned int y = get_global_id(1) * 256;
-    // const unsigned int local_row = get_local_id(1);
     const unsigned int x = get_global_id(0);
     if (x >= width || y >= height) {
         return;
     }
-    // printf("x: %d   y: %d   id0: %d   id1: %d   local_id0: %d   local_id1: %d\n", 
-    //     x, y, get_global_id(0), get_global_id(1), get_local_id(0), local_row);
-    // printf("global_size0: %d   global_size1: %d\n", get_global_size(0), get_global_size(1));
-    // printf("local_size0: %d   local_size1: %d\n", get_local_size(0), get_local_size(1));
     const unsigned int yBound = min(y + 256, height);
-    // get_global_offset()
-    // printf("moving down\n");
     for (; y < yBound; ++y) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
-        // printf("x: %d  y: %d  idx: %d  a[idx]: %d  b[idx]: %d  c[idx]: %d\n", 
-        //     x, y, idx, a[idx], b[idx], c[idx]);
     }
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void aplusb_matrix_good(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,14 +17,15 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
-    unsigned int x = get_global_id(0) * 256;
-    const unsigned int y = get_global_id(1);
+    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+
+    unsigned int y = get_global_id(1) * 256;
+    const unsigned int x = get_global_id(0);
     if (x >= width || y >= height) {
         return;
     }
-    const unsigned int xBound = min(x + 256, width);
-    for (; x < xBound; ++x) {
+    const unsigned int yBound = min(y + 256, height);
+    for (; y < yBound; ++y) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
     }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
+__attribute__((reqd_work_group_size(1, GROUP_SIZE, 1)))
 __kernel void aplusb_matrix_good(__global const uint* a,
                      __global const uint* b,
                      __global       uint* c,
@@ -17,15 +17,14 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
-
-    unsigned int y = get_global_id(1) * 256;
-    const unsigned int x = get_global_id(0);
+    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    unsigned int x = get_global_id(0) * 256;
+    const unsigned int y = get_global_id(1);
     if (x >= width || y >= height) {
         return;
     }
-    const unsigned int yBound = min(y + 256, height);
-    for (; y < yBound; ++y) {
+    const unsigned int xBound = min(x + 256, width);
+    for (; x < xBound; ++x) {
         int idx = y * width + x;
         c[idx] = a[idx] + b[idx];
     }

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -37,8 +37,7 @@ void run(int argc, char** argv)
     avk2::KernelSource vk_aplusb_matrix_bad(avk2::getAplusBMatrixBad());
     avk2::KernelSource vk_aplusb_matrix_good(avk2::getAplusBMatrixGood());
 
-    // unsigned int task_size = 64;
-    unsigned int task_size = 1;
+    unsigned int task_size = 64;
     unsigned int width = task_size * 256;
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
@@ -93,14 +92,6 @@ void run(int argc, char** argv)
         std::vector<unsigned int> cs(n, 0);
         c_gpu.readN(cs.data(), n);
 
-        // for (int i = 0; i < height; ++i) {
-        //     for (int j = 0; j < width; ++j) {
-        //         std::cout << cs[i * height + width] << ' '; 
-        //     }
-        //     std::cout << std::endl;
-        // }
-        // std::cout << std::endl;
-
         // Сверяем результат
         for (size_t i = 0; i < n; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230421312512, cs[i], as[i] + bs[i], i);
@@ -127,11 +118,6 @@ void run(int argc, char** argv)
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(n, 0);
         c_gpu.readN(cs.data(), n);
-
-        // for (int i = 0; i < 100; ++i) {
-        //     std::cout << cs[i] << ' '; 
-        // }
-        // std::cout << std::endl;
 
         // Сверяем результат
         for (size_t i = 0; i < n; ++i) {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -38,7 +38,7 @@ void run(int argc, char** argv)
     avk2::KernelSource vk_aplusb_matrix_good(avk2::getAplusBMatrixGood());
 
     // unsigned int task_size = 64;
-    unsigned int task_size = 2;
+    unsigned int task_size = 1;
     unsigned int width = task_size * 256;
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
@@ -67,13 +67,13 @@ void run(int argc, char** argv)
 
         // Запускаем кернел (несколько раз и с замером времени выполнения)
         std::vector<double> times;
-        // for (int iter = 0; iter < 10; ++iter) {
+        for (int iter = 0; iter < 10; ++iter) {
             timer t;
 
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 256, (width + 255) / 256, (height + 255) / 256);
+            gpu::WorkSize workSize(1, 256, (width + 255) / 256, height);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
@@ -81,7 +81,7 @@ void run(int argc, char** argv)
             ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
 
             times.push_back(t.elapsed());
-        // }
+        }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
         // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
@@ -115,7 +115,7 @@ void run(int argc, char** argv)
         std::vector<double> times;
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
-            gpu::WorkSize workSize(1, 256, height,width);
+            gpu::WorkSize workSize(256, 1, width, (height + 255) / 256);
             ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             times.push_back(t.elapsed());
         }

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -72,7 +72,7 @@ void run(int argc, char** argv)
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 256, (width + 255) / 256, height);
+            gpu::WorkSize workSize(GROUP_SIZE, 1, width, (height + GROUP_SIZE - 1) / GROUP_SIZE);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
@@ -106,7 +106,7 @@ void run(int argc, char** argv)
         std::vector<double> times;
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
-            gpu::WorkSize workSize(256, 1, width, (height + 255) / 256);
+            gpu::WorkSize workSize(1, GROUP_SIZE, (width + GROUP_SIZE - 1) / GROUP_SIZE, height);
             ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             times.push_back(t.elapsed());
         }

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -55,7 +55,7 @@ void run(int argc, char** argv)
 
     // Аллоцируем буферы в VRAM
     gpu::gpu_mem_32u a_gpu(n), b_gpu(n), c_gpu(n);
-    
+
     // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
     // rassert(false, 5462345134123);
     a_gpu.writeN(as.data(), n);
@@ -72,7 +72,7 @@ void run(int argc, char** argv)
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(GROUP_SIZE, 1, width, (height + GROUP_SIZE - 1) / GROUP_SIZE);
+            gpu::WorkSize workSize(1, GROUP_SIZE, (width + GROUP_SIZE - 1) / GROUP_SIZE, height);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
@@ -102,11 +102,11 @@ void run(int argc, char** argv)
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
-        
+
         std::vector<double> times;
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
-            gpu::WorkSize workSize(1, GROUP_SIZE, (width + GROUP_SIZE - 1) / GROUP_SIZE, height);
+            gpu::WorkSize workSize(GROUP_SIZE, 1, width, (height + GROUP_SIZE - 1) / GROUP_SIZE);
             ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             times.push_back(t.elapsed());
         }
@@ -135,7 +135,8 @@ int main(int argc, char** argv)
         if (e.what() == DEVICE_NOT_SUPPORT_API) {
             // Возвращаем exit code = 0 чтобы на CI не было красного крестика о неуспешном запуске из-за выбора CUDA API (его нет на процессоре - т.е. в случае CI на GitHub Actions)
             return 0;
-        } if (e.what() == CODE_IS_NOT_IMPLEMENTED) {
+        }
+        if (e.what() == CODE_IS_NOT_IMPLEMENTED) {
             // Возвращаем exit code = 0 чтобы на CI не было красного крестика о неуспешном запуске из-за того что задание еще не выполнено
             return 0;
         } else {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -37,69 +37,72 @@ void run(int argc, char** argv)
     avk2::KernelSource vk_aplusb_matrix_bad(avk2::getAplusBMatrixBad());
     avk2::KernelSource vk_aplusb_matrix_good(avk2::getAplusBMatrixGood());
 
-    unsigned int task_size = 64;
+    // unsigned int task_size = 64;
+    unsigned int task_size = 2;
     unsigned int width = task_size * 256;
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
     // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+    // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
-    std::vector<unsigned int> as(width * height, 0);
-    std::vector<unsigned int> bs(width * height, 0);
-    for (size_t i = 0; i < width * height; ++i) {
+    unsigned int n = width * height;
+    std::vector<unsigned int> as(n, 0);
+    std::vector<unsigned int> bs(n, 0);
+    for (size_t i = 0; i < n; ++i) {
         as[i] = 3 * (i + 5) + 7;
         bs[i] = 11 * (i + 13) + 17;
     }
 
     // Аллоцируем буферы в VRAM
-    gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
-
+    gpu::gpu_mem_32u a_gpu(n), b_gpu(n), c_gpu(n);
+    
     // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    // rassert(false, 5462345134123);
+    a_gpu.writeN(as.data(), n);
+    b_gpu.writeN(bs.data(), n);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
 
         // Запускаем кернел (несколько раз и с замером времени выполнения)
         std::vector<double> times;
-        for (int iter = 0; iter < 10; ++iter) {
+        // for (int iter = 0; iter < 10; ++iter) {
             timer t;
 
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(1, 256, (width + 255) / 256, (height + 255) / 256);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
             // TODO раскомментируйте вызов вашего API и поправьте его
-            if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeVulkan) {
-                struct {
-                    unsigned int width;
-                    unsigned int height;
-                } params = { width, height };
-                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
-            } else {
-                rassert(false, 4531412341, context.type());
-            }
+            ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
 
             times.push_back(t.elapsed());
-        }
+        // }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
         // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        // rassert(false, 54623414231);
+        double memory_size_gb = sizeof(unsigned int) * 3 * n / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b BAD maxrix kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
-        std::vector<unsigned int> cs(width * height, 0);
+        std::vector<unsigned int> cs(n, 0);
+        c_gpu.readN(cs.data(), n);
+
+        // for (int i = 0; i < height; ++i) {
+        //     for (int j = 0; j < width; ++j) {
+        //         std::cout << cs[i * height + width] << ' '; 
+        //     }
+        //     std::cout << std::endl;
+        // }
+        // std::cout << std::endl;
 
         // Сверяем результат
-        for (size_t i = 0; i < width * height; ++i) {
+        for (size_t i = 0; i < n; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230421312512, cs[i], as[i] + bs[i], i);
         }
     }
@@ -108,12 +111,30 @@ void run(int argc, char** argv)
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
+            gpu::WorkSize workSize(1, 256, height,width);
+            ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        double memory_size_gb = sizeof(unsigned int) * 3 * n / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b GOOD maxrix kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
-        std::vector<unsigned int> cs(width * height, 0);
+        std::vector<unsigned int> cs(n, 0);
+        c_gpu.readN(cs.data(), n);
+
+        // for (int i = 0; i < 100; ++i) {
+        //     std::cout << cs[i] << ' '; 
+        // }
+        // std::cout << std::endl;
 
         // Сверяем результат
-        for (size_t i = 0; i < width * height; ++i) {
+        for (size_t i = 0; i < n; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230365731436, cs[i], as[i] + bs[i], i);
         }
     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./build/main_aplusb_matrix 2
Found 4 GPUs in 0.085095 sec (OpenCL: 0.067226 sec, Vulkan: 0.017815 sec)
Available devices:
  Device #0: API: Vulkan. iGPU. AMD Radeon Graphics (RADV RENOIR). Free memory: 6559/7299 Mb.
  Device #1: API: OpenCL. GPU. AMD Radeon Graphics (radeonsi, renoir, ACO, DRM 3.57, 6.8.0-85-generic). Total memory: 8901 Mb.
  Device #2: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 17803 Mb.
  Device #3: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 17803/17803 Mb.
Using device #2: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 17803 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.127604 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.139913 10%=0.140637 median=0.142445 90%=0.320726 max=0.320726)
a + b BAD maxrix kernel median VRAM bandwidth: 10.5304 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.038106 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.195012 10%=0.195481 median=0.196237 90%=0.239124 max=0.239124)
a + b GOOD maxrix kernel median VRAM bandwidth: 7.64382 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./enumDevices
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: 
The command "./enumDevices" exited with 0.
</pre>

</p></details>
