### PR TITLE
Task01 Roman Kremer ITMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build*
 cmake-build*
 .vs
+.vscode

--- a/src/kernels/cl/aplusb_matrix_bad.cl
+++ b/src/kernels/cl/aplusb_matrix_bad.cl
@@ -16,5 +16,11 @@ __kernel void aplusb_matrix_bad(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+
+    const unsigned int index = x * height + y;
+    if (index < height * width) {
+        c[index] = a[index] + b[index];
+    }
 }

--- a/src/kernels/cl/aplusb_matrix_good.cl
+++ b/src/kernels/cl/aplusb_matrix_good.cl
@@ -16,5 +16,11 @@ __kernel void aplusb_matrix_good(__global const uint* a,
     // т.е. если в матрице сделать шаг вправо или влево на одну ячейку - то в памяти мы шагнем на 4 байта
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
-    // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+
+    const unsigned int index = y * width + x;
+    if (index < height * width) {
+        c[index] = a[index] + b[index];
+    }
 }

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -34,16 +34,10 @@ void run(int argc, char** argv)
     ocl::KernelSource ocl_aplusb_matrix_bad(ocl::getAplusBMatrixBad());
     ocl::KernelSource ocl_aplusb_matrix_good(ocl::getAplusBMatrixGood());
 
-    avk2::KernelSource vk_aplusb_matrix_bad(avk2::getAplusBMatrixBad());
-    avk2::KernelSource vk_aplusb_matrix_good(avk2::getAplusBMatrixGood());
-
     unsigned int task_size = 64;
     unsigned int width = task_size * 256;
     unsigned int height = task_size * 128;
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
-
-    // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
@@ -54,9 +48,8 @@ void run(int argc, char** argv)
 
     // Аллоцируем буферы в VRAM
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
-
-    // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
+    a_gpu.writeN(as.data(), width * height);
+    b_gpu.writeN(bs.data(), width * height);
 
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
@@ -66,39 +59,16 @@ void run(int argc, char** argv)
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
 
-            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
-            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
-            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(256, 1, width, height);
 
-            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
-            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
-            // TODO раскомментируйте вызов вашего API и поправьте его
-            if (context.type() == gpu::Context::TypeOpenCL) {
-                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
-            } else if (context.type() == gpu::Context::TypeVulkan) {
-                struct {
-                    unsigned int width;
-                    unsigned int height;
-                } params = { width, height };
-                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
-            } else {
-                rassert(false, 4531412341, context.type());
-            }
-
+            ocl_aplusb_matrix_bad.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
             times.push_back(t.elapsed());
         }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
-        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
-
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
-        // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230421312512, cs[i], as[i] + bs[i], i);
         }
@@ -107,12 +77,20 @@ void run(int argc, char** argv)
     {
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
-        // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
 
-        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+            gpu::WorkSize workSize(256, 1, width, height);
+
+            ocl_aplusb_matrix_good.exec(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
-        // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230365731436, cs[i], as[i] + bs[i], i);
         }

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -66,6 +66,9 @@ void run(int argc, char** argv)
         }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
+
         std::vector<unsigned int> cs(width * height, 0);
         c_gpu.readN(cs.data(), width * height);
 
@@ -87,6 +90,9 @@ void run(int argc, char** argv)
             times.push_back(t.elapsed());
         }
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        double memory_size_gb = sizeof(unsigned int) * 3 * width * height / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b kernel median VRAM bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
         std::vector<unsigned int> cs(width * height, 0);
         c_gpu.readN(cs.data(), width * height);


### PR DESCRIPTION
Local
<pre>
Found 2 GPUs in 1.74565 sec (OpenCL: 0.975905 sec, Vulkan: 0.769617 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12450H. Intel(R) Corporation. Total memory: 7801 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 7801/7801 Mb.
Using device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12450H. Intel(R) Corporation. Total memory: 7801 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.41335 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.157105 10%=0.941655 median=1.08229 90%=1.59971 max=1.59971)
a + b kernel median VRAM bandwidth: 1.38595 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.098584 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.03507 10%=0.035307 median=0.036913 90%=0.168667 max=0.168667)
a + b kernel median VRAM bandwidth: 40.6361 GB/s</pre>
Github
<pre>
Found 2 GPUs in 0.044176 sec (CUDA: 8.1e-05 sec, OpenCL: 0.019989 sec, Vulkan: 0.024063 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
Kernels compilation done in 0.131075 seconds
a + b matrix kernel times (in seconds) - 10 values (min=1.43594 10%=1.52335 median=1.84078 90%=2.38673 max=2.38673)
a + b kernel median VRAM bandwidth: 0.81487 GB/s
Running GOOD matrix kernel...
Kernels compilation done in 0.028317 seconds
a + b matrix kernel times (in seconds) - 10 values (min=0.110906 10%=0.110915 median=0.111276 90%=0.140501 max=0.140501)
a + b kernel median VRAM bandwidth: 13.48 GB/s
</pre>