### PR TITLE
Task01 Melnikov Vladimir ITMO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 **/generated_kernels/*
 .idea
 build*
+scripts/*/*.zip*
+scripts/*/*Vulkan*
 cmake-build*
 .vs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(GPGPUTasks)
 set(CMAKE_CXX_STANDARD 17)
 
 # Если вы установили CUDA SDK - можете включить поддержку CUDA
-option(GPU_CUDA_SUPPORT "CUDA support." OFF)
+option(GPU_CUDA_SUPPORT "CUDA support." ON)
 
 # GLSLC_BIN используйтся для компиляции Vulkan шейдеров (GLSL)
 if (NOT DEFINED GLSLC_BIN)

--- a/scripts/linux/install_vulkan_sdk.sh
+++ b/scripts/linux/install_vulkan_sdk.sh
@@ -4,7 +4,7 @@
 set -ev
 
 # Parse script arguments to skip validation layers if --no-validation-layers is present
-SKIP_VALIDATION_LAYERS=0
+SKIP_VALIDATION_LAYERS=1
 for arg in "$@"; do
   [ "$arg" = "--no-validation-layers" ] && SKIP_VALIDATION_LAYERS=1
 done

--- a/src/kernels/cu/aplusb_matrix_bad.cu
+++ b/src/kernels/cu/aplusb_matrix_bad.cu
@@ -26,7 +26,7 @@ __global__ void aplusb_matrix_bad(const unsigned int* a,
         return;
     }
 
-    int idx = x * height + y;
+    int idx = y * width + x;
     c[idx] = a[idx] + b[idx];
 }
 

--- a/src/kernels/cu/aplusb_matrix_bad.cu
+++ b/src/kernels/cu/aplusb_matrix_bad.cu
@@ -19,6 +19,15 @@ __global__ void aplusb_matrix_bad(const unsigned int* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ПЛОХУЮ производительность с точки зрения memory coalesced паттерна доступа
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= width || y >= height) {
+        return;
+    }
+
+    int idx = x * height + y;
+    c[idx] = a[idx] + b[idx];
 }
 
 namespace cuda {

--- a/src/kernels/cu/aplusb_matrix_good.cu
+++ b/src/kernels/cu/aplusb_matrix_good.cu
@@ -26,7 +26,7 @@ __global__ void aplusb_matrix_good(const unsigned int* a,
         return;
     }
 
-    int idx = y * width + x;
+    int idx = x * height + y;
     c[idx] = a[idx] + b[idx];
 }
 

--- a/src/kernels/cu/aplusb_matrix_good.cu
+++ b/src/kernels/cu/aplusb_matrix_good.cu
@@ -19,6 +19,15 @@ __global__ void aplusb_matrix_good(const unsigned int* a,
     // т.е. если в матрице сделать шаг вверх или вниз на одну ячейку - то в памяти мы шагнем на так называемый stride=width*4 байта
 
     // TODO реализуйте этот кернел - просуммируйте две матрицы так чтобы получить максимально ХОРОШУЮ производительность с точки зрения memory coalesced паттерна доступа
+    int x = blockIdx.x * blockDim.x + threadIdx.x;
+    int y = blockIdx.y * blockDim.y + threadIdx.y;
+
+    if (x >= width || y >= height) {
+        return;
+    }
+
+    int idx = y * width + x;
+    c[idx] = a[idx] + b[idx];
 }
 
 namespace cuda {

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -12,7 +12,7 @@
 #include <vector>
 #include <iostream>
 
-#define MAX_ITERS 30
+#define MAX_ITERS 10
 //#define DEBUG_WGPS
 
 void run(int argc, char** argv)

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -23,7 +23,7 @@ void run(int argc, char** argv)
     // TODO 100 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 100 после этого реализуйте два кернела - максимально эффективный и максимально неэффктивный вариант сложения матриц - src/kernels/<ваш выбор>/aplusb_matrix_<bad/good>.<ваш выбор>
     // TODO 100 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -43,7 +43,7 @@ void run(int argc, char** argv)
     std::cout << "matrices size: " << width << "x" << height << " = 3 * " << (sizeof(unsigned int) * width * height / 1024 / 1024) << " MB" << std::endl;
 
     // TODO Удалите эту строку, она для того чтобы моя заготовка (не работающий код) не пыталась запуститься на CI
-    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+    //throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
     std::vector<unsigned int> as(width * height, 0);
     std::vector<unsigned int> bs(width * height, 0);
@@ -56,8 +56,9 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u a_gpu(width * height), b_gpu(width * height), c_gpu(width * height);
 
     // TODO Удалите этот rassert - прогрузите входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    rassert(false, 5462345134123);
-
+    //rassert(false, 5462345134123);
+    a_gpu.writeN(as.data(), n);
+    b_gpu.writeN(bs.data(), n);
     {
         std::cout << "Running BAD matrix kernel..." << std::endl;
 
@@ -69,7 +70,7 @@ void run(int argc, char** argv)
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
             // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
             // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
-            gpu::WorkSize workSize(1, 1, width, height);
+            gpu::WorkSize workSize(1, 256, (255+width)/256, height);
 
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
@@ -77,7 +78,7 @@ void run(int argc, char** argv)
             if (context.type() == gpu::Context::TypeOpenCL) {
                 // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
             } else if (context.type() == gpu::Context::TypeCUDA) {
-                // cuda::aplusb_matrix_bad(workSize, a_gpu, ...);
+                cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, width, height);
             } else if (context.type() == gpu::Context::TypeVulkan) {
                 struct {
                     unsigned int width;
@@ -93,10 +94,11 @@ void run(int argc, char** argv)
         std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
 
         // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
-        rassert(false, 54623414231);
+        //rassert(false, 54623414231);
 
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
 
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
@@ -108,10 +110,35 @@ void run(int argc, char** argv)
         std::cout << "Running GOOD matrix kernel..." << std::endl;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        timer t;
 
+        // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+        // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
+        // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+        gpu::WorkSize workSize(1, 256, (255+width)/256, height);
+
+        // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+        // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
+        // TODO раскомментируйте вызов вашего API и поправьте его
+        if (context.type() == gpu::Context::TypeOpenCL) {
+            // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+        } else if (context.type() == gpu::Context::TypeCUDA) {
+            cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, width, height);
+        } else if (context.type() == gpu::Context::TypeVulkan) {
+            struct {
+                unsigned int width;
+                unsigned int height;
+            } params = { width, height };
+            // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+        } else {
+            rassert(false, 4531412341, context.type());
+        }
+
+        times.push_back(t.elapsed());
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
         // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
         std::vector<unsigned int> cs(width * height, 0);
-
+        c_gpu.readN(cs.data(), width * height);
         // Сверяем результат
         for (size_t i = 0; i < width * height; ++i) {
             rassert(cs[i] == as[i] + bs[i], 321418230365731436, cs[i], as[i] + bs[i], i);

--- a/src/main_aplusb_matrix.cpp
+++ b/src/main_aplusb_matrix.cpp
@@ -12,6 +12,8 @@
 #include <vector>
 #include <iostream>
 
+#define MAX_ITERS 30
+//#define DEBUG_WGPS
 
 void run(int argc, char** argv)
 {
@@ -67,7 +69,7 @@ void run(int argc, char** argv)
 
         // Запускаем кернел (несколько раз и с замером времени выполнения)
         std::vector<double> times;
-        for (int iter = 0; iter < 10; ++iter) {
+        for (int iter = 0; iter < MAX_ITERS; ++iter) {
             timer t;
 
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
@@ -122,7 +124,7 @@ void run(int argc, char** argv)
         std::vector<double> times;
 
         // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
-        for (int iter = 0; iter < 10; ++iter) {
+        for (int iter = 0; iter < MAX_ITERS; ++iter) {
             timer t;
 
             // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
@@ -163,6 +165,111 @@ void run(int argc, char** argv)
             rassert(cs[i] == as[i] + bs[i], 321418230365731436, cs[i], as[i] + bs[i], i);
         }
     }
+
+
+    #ifdef DEBUG_WGPS
+        {
+        std::cout << "Running (wrong dims) BAD matrix kernel..." << std::endl;
+
+        // Запускаем кернел (несколько раз и с замером времени выполнения)
+        std::vector<double> times;
+        for (int iter = 0; iter < MAX_ITERS; ++iter) {
+            timer t;
+
+            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
+            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+            
+            // 		WorkSize(size_t groupSizeX, size_t groupSizeY, size_t workSizeX, size_t workSizeY)
+            // для good рядом стоят y, не рядом стоят x
+            // для bad все наоборот
+            //    int idx = y * width + x;
+
+            gpu::WorkSize workSize(256, 1, width, height);
+
+            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
+            // TODO раскомментируйте вызов вашего API и поправьте его
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                cuda::aplusb_matrix_bad(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeVulkan) {
+                struct {
+                    unsigned int width;
+                    unsigned int height;
+                } params = { width, height };
+                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+
+        // TODO Удалите этот rassert - вычислите достигнутую эффективную пропускную способность видеопамяти
+        double memory_size_in_gb = sizeof(unsigned int) * 3 * (width*height) / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b matrix kernel median VRAM bandwidth: " << memory_size_in_gb / stats::median(times) << " GB/s" << std::endl;
+        //rassert(false, 54623414231);
+
+        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+        std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
+
+        // Сверяем результат
+        for (size_t i = 0; i < width * height; ++i) {
+            rassert(cs[i] == as[i] + bs[i], 321418230421312512, cs[i], as[i] + bs[i], i);
+        }
+    }
+
+    {
+        std::cout << "Running GOOD (wrong dims) matrix kernel..." << std::endl;
+        std::vector<double> times;
+
+        // TODO Почти тот же код что с плохим кернелом, но теперь с хорошим, рекомендуется копи-паста
+        for (int iter = 0; iter < MAX_ITERS; ++iter) {
+            timer t;
+
+            // Настраиваем размер рабочего пространства (n) и размер рабочих групп в этом рабочем пространстве (GROUP_SIZE=256)
+            // Обратите внимание что сейчас указана рабочая группа размера 1х1 в рабочем пространстве width x height, это не то что вы хотите
+            // TODO И в плохом и в хорошем кернеле рабочая группа обязана состоять из 256 work-items
+            //    int idx = x * height + y;
+
+            gpu::WorkSize workSize(256, 1, width, height);
+            // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
+            // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
+            // TODO раскомментируйте вызов вашего API и поправьте его
+            if (context.type() == gpu::Context::TypeOpenCL) {
+                // ocl_aplusb_matrix_bad.exec(workSize, a_gpu, ...);
+            } else if (context.type() == gpu::Context::TypeCUDA) {
+                cuda::aplusb_matrix_good(workSize, a_gpu, b_gpu, c_gpu, width, height);
+            } else if (context.type() == gpu::Context::TypeVulkan) {
+                struct {
+                    unsigned int width;
+                    unsigned int height;
+                } params = { width, height };
+                // vk_aplusb_matrix_bad.exec(params, workSize, a_gpu, ...);
+            } else {
+                rassert(false, 4531412341, context.type());
+            }
+
+            times.push_back(t.elapsed());
+        }
+        std::cout << "a + b matrix kernel times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+        
+        double memory_size_in_gb = sizeof(unsigned int) * 3 * (width*height) / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "a + b matrix kernel median VRAM bandwidth: " << memory_size_in_gb / stats::median(times) << " GB/s" << std::endl;
+        // TODO Считываем результат по PCI-E шине: GPU VRAM -> CPU RAM
+        std::vector<unsigned int> cs(width * height, 0);
+        c_gpu.readN(cs.data(), width * height);
+        // Сверяем результат
+        for (size_t i = 0; i < width * height; ++i) {
+            rassert(cs[i] == as[i] + bs[i], 321418230365731436, cs[i], as[i] + bs[i], i);
+        }
+    }
+    #endif
+
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
<details>
<summary>Локальный запуск</summary>

```

vova:~/GPGPUTasks2025/build$ ./main_aplusb_matrix 0
Found 2 GPUs in 1.58815 sec (CUDA: 1.39805 sec, OpenCL: 0.146999 sec, Vulkan: 0.043055 sec)
Available devices:
  Device #0: API: CUDA+OpenCL. GPU. NVIDIA GeForce RTX 3050 Laptop GPU (CUDA 12080). Free memory: 3238/4095 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 6863/6863 Mb.
Using device #0: API: CUDA+OpenCL. GPU. NVIDIA GeForce RTX 3050 Laptop GPU (CUDA 12080). Free memory: 3238/4095 Mb.
Using CUDA API...
matrices size: 16384x8192 = 3 * 512 MB
Running BAD matrix kernel...
a + b matrix kernel times (in seconds) - 30 values (min=0.03543 10%=0.035581 median=0.0358 90%=0.037864 max=0.038436)
a + b matrix kernel median VRAM bandwidth: 41.8994 GB/s
Running GOOD matrix kernel...
a + b matrix kernel times (in seconds) - 30 values (min=0.008774 10%=0.008784 median=0.008828 90%=0.009111 max=0.00986)
a + b matrix kernel median VRAM bandwidth: 169.914 GB/s
Running (wrong dims) BAD matrix kernel...
a + b matrix kernel times (in seconds) - 30 values (min=0.008805 10%=0.008814 median=0.008852 90%=0.008908 max=0.009182)
a + b matrix kernel median VRAM bandwidth: 169.453 GB/s
Running GOOD (wrong dims) matrix kernel...
a + b matrix kernel times (in seconds) - 30 values (min=0.249713 10%=0.249757 median=0.249804 90%=0.249894 max=0.250089)
a + b matrix kernel median VRAM bandwidth: 6.00471 GB/s
```


wrong dims -- "а что если поменять местами размер групп для X и Y" (в том что запускается в ранере отключено)
оказалось, что "плохой" некоалесд кернал всего на 0.27% будет медленнее хорошего 
а "хороший" коалесед в 28 раз медленее?
возможно я перепутал в голове иксы и игреки для хорошего и плохого, но тогда странно что при "хороших" размерах групп самый быстрый "хороший" и при плохих размерах он так плохо справляется
//
P.S. Теоритическая максимальная пропускная способность шины 192 GB/s, но тут возможно мешал гипервизор
</details>