### PR TITLE
Task02 Даниил Сухоруков ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,29 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0 * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold) ) / log(2.0f);
+    }
+
+    result = result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -10,10 +10,22 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        const unsigned int n)
 {
     // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index >= n) {
+        local_data[local_index] = 0;
+    } else {
+        local_data[local_index] = a[index];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (local_index == 0) {
+        uint my_sum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            my_sum += local_data[i];
+        }
+        atomic_add(sum, my_sum);
+    }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -12,10 +12,24 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                             unsigned int  n)
 {
     // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index >= n) {
+        local_data[local_index] = 0;
+    } else {
+        local_data[local_index] = a[index];
+    }
+
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint my_sum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            my_sum += local_data[i];
+        }
+        b[get_group_id(0)] = my_sum;
+    }
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -122,7 +122,9 @@ void run(int argc, char** argv)
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
                     // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -72,10 +72,23 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u reduction_buffer2_gpu(div_ceil(n, (unsigned int)GROUP_SIZE));
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    input_gpu.writeN(values.data(), n);
     // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
     // TODO 2) сделайте замер хотя бы три раза
     // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    std::vector<double> pcie_times;
+    const int pcie_measurements = 3;
+
+    for (int i = 0; i < pcie_measurements; ++i) {
+        timer pcie_timer;
+        input_gpu.writeN(values.data(), n);
+        pcie_times.push_back(pcie_timer.elapsed());
+    }
+
+    double bandwidth_gbps = (n * sizeof(unsigned int) / stats::median(pcie_times)) / (1024.0 * 1024.0 * 1024.0);
+
+    std::cout << "PCI-E bandwidth measurements (times in seconds): " << stats::valuesStatsLine(pcie_times) << std::endl;
+    std::cout << "PCI-E bandwidth: " << std::fixed << std::setprecision(2) << bandwidth_gbps << " GB/s" << std::endl;
+    
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -114,10 +127,26 @@ void run(int argc, char** argv)
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
                         // TODO ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
                         // TODO ocl_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, reduction_buffer2_gpu, n);
+                        unsigned int count = div_ceil(n, (unsigned int)GROUP_SIZE);
+                        bool use_first_buffer = false;
+                        while (count > 1) {
+                            std::swap(reduction_buffer1_gpu, reduction_buffer2_gpu);
+                            ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, count), reduction_buffer1_gpu, reduction_buffer2_gpu, count);
+                            count = div_ceil(count, (unsigned int)GROUP_SIZE);
+                            use_first_buffer = !use_first_buffer;
+                        }
+                        if (!use_first_buffer) {
+                            std::swap(reduction_buffer1_gpu, reduction_buffer2_gpu);
+                        }
+                        reduction_buffer2_gpu.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 1 GPUs in 0.0263081 sec (OpenCL: 0.025082 sec, Vulkan: 0.001187 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7713P 64-Core Processor               . Intel(R) Corporation. Total memory: 9941 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7713P 64-Core Processor               . Intel(R) Corporation. Total memory: 9941 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=4.78297 10%=4.78297 median=4.78297 90%=4.78297 max=4.78297)
Mandelbrot effective algorithm GFlops: 2.09075 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=1.38501 10%=1.38528 median=1.3859 90%=1.43873 max=1.43873)
Mandelbrot effective algorithm GFlops: 7.21551 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.145393 seconds
algorithm times (in seconds) - 10 values (min=0.194189 10%=0.19474 median=0.196565 90%=0.344892 max=0.344892)
Mandelbrot effective algorithm GFlops: 50.8738 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 1 GPUs in 0.322755 sec (OpenCL: 0.316975 sec, Vulkan: 0.00573411 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7713P 64-Core Processor               . Intel(R) Corporation. Total memory: 9941 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7713P 64-Core Processor               . Intel(R) Corporation. Total memory: 9941 Mb.
Using OpenCL API...
PCI-E bandwidth measurements (times in seconds): 3 values (min=0.0164064 10%=0.0164064 median=0.0165046 90%=0.0650904 max=0.0650904)
PCI-E bandwidth: 22.57 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.135971 10%=0.136051 median=0.136917 90%=0.137756 max=0.137756)
sum median effective algorithm bandwidth: 2.72 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0389455 10%=0.0390005 median=0.0395677 90%=0.0552846 max=0.0552846)
sum median effective algorithm bandwidth: 9.41 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.31 seconds
algorithm times (in seconds) - 10 values (min=0.982085 10%=0.983682 median=1.06499 90%=1.51953 max=1.51953)
sum median effective algorithm bandwidth: 0.35 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.03 seconds
algorithm times (in seconds) - 10 values (min=0.532739 10%=0.573139 median=0.631026 90%=0.885232 max=0.885232)
sum median effective algorithm bandwidth: 0.59 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.05 seconds
algorithm times (in seconds) - 10 values (min=0.0436095 10%=0.0437718 median=0.0453137 90%=0.0954625 max=0.0954625)
sum median effective algorithm bandwidth: 8.22 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.04 seconds
algorithm times (in seconds) - 10 values (min=0.0447632 10%=0.0449146 median=0.0457906 90%=0.0865929 max=0.0865929)
sum median effective algorithm bandwidth: 8.14 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot
Found 2 GPUs in 0.0449655 sec (CUDA: 8.0189e-05 sec, OpenCL: 0.0199635 sec, Vulkan: 0.0248757 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=1.99936 10%=1.99936 median=1.99936 90%=1.99936 max=1.99936)
Mandelbrot effective algorithm GFlops: 5.0016 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.60195 10%=0.601995 median=0.654503 90%=0.7634 max=0.7634)
Mandelbrot effective algorithm GFlops: 15.2788 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.155941 seconds
algorithm times (in seconds) - 10 values (min=0.276173 10%=0.276235 median=0.276445 90%=0.434342 max=0.434342)
Mandelbrot effective algorithm GFlops: 36.1736 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 2 GPUs in 0.0465465 sec (CUDA: 0.000105245 sec, OpenCL: 0.0210931 sec, Vulkan: 0.0253057 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCI-E bandwidth measurements (times in seconds): 3 values (min=0.0232227 10%=0.0232227 median=0.0233565 90%=0.0281878 max=0.0281878)
PCI-E bandwidth: 15.95 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0625893 10%=0.0626217 median=0.0627548 90%=0.0679487 max=0.0679487)
sum median effective algorithm bandwidth: 5.94 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0211357 10%=0.0211643 median=0.0212813 90%=0.0216601 max=0.0216601)
sum median effective algorithm bandwidth: 17.51 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.11 seconds
algorithm times (in seconds) - 10 values (min=1.5119 10%=1.51345 median=1.5165 90%=1.63853 max=1.63853)
sum median effective algorithm bandwidth: 0.25 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.03 seconds
algorithm times (in seconds) - 10 values (min=0.761459 10%=0.76269 median=0.762986 90%=0.792666 max=0.792666)
sum median effective algorithm bandwidth: 0.49 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.05 seconds
algorithm times (in seconds) - 10 values (min=0.0571616 10%=0.0571833 median=0.0574515 90%=0.104077 max=0.104077)
sum median effective algorithm bandwidth: 6.48 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.04 seconds
algorithm times (in seconds) - 10 values (min=0.0653061 10%=0.0653478 median=0.0655005 90%=0.10308 max=0.10308)
sum median effective algorithm bandwidth: 5.69 GB/s
</pre>

</p></details>