### PR TITLE
Task02 Илья Виноградов HSE

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,33 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    if (i >= width || j >= height) {
+        return;
+    }
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * iter / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -10,10 +10,24 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        const unsigned int n)
 {
     // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint local_sum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+
+        atomic_add(sum, local_sum);
+    }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -12,10 +12,26 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                             unsigned int  n)
 {
     // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint index_in_result = index / GROUP_SIZE;
+        uint local_sum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+
+        b[index_in_result] = local_sum;
+    }
     // TODO
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,9 +121,8 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
+                    gpu::WorkSize workGroup(16, 16, width, height);
+                    ocl_mandelbrot.exec(workGroup, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
                     // TODO cuda::mandelbrot(..);


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 4 GPUs in 0.145444 sec (OpenCL: 0.0663787 sec, Vulkan: 0.078975 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 15610 Mb.
  Device #1: API: Vulkan. iGPU. Intel(R) Iris(R) Xe Graphics (ADL GT2). Free memory: 7024/7805 Mb.
  Device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Free memory: 3751/3768 Mb.
  Device #3: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15610/15610 Mb.
Using device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Free memory: 3751/3768 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=5.30815 10%=5.30815 median=5.30815 90%=5.30815 max=5.30815)
Mandelbrot effective algorithm GFlops: 1.8839 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x20 threads
algorithm times (in seconds) - 10 values (min=0.624868 10%=0.629629 median=0.646485 90%=0.728662 max=0.728662)
Mandelbrot effective algorithm GFlops: 15.4683 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Failed to read file: /tmp/dep-d15711.d
Kernels compilation done in 0.0615276 seconds
algorithm times (in seconds) - 10 values (min=0.00326613 10%=0.00326956 median=0.00329649 90%=0.0647173 max=0.0647173)
Mandelbrot effective algorithm GFlops: 3033.53 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 4 GPUs in 0.160668 sec (OpenCL: 0.0676475 sec, Vulkan: 0.0928851 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i7-12700H. Intel(R) Corporation. Total memory: 15611 Mb.
  Device #1: API: Vulkan. iGPU. Intel(R) Iris(R) Xe Graphics (ADL GT2). Free memory: 7024/7805 Mb.
  Device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Free memory: 3751/3768 Mb.
  Device #3: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15611/15611 Mb.
Using device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Laptop GPU. Free memory: 3751/3768 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.348468 10%=0.349031 median=0.349417 90%=0.538363 max=0.538363)
sum median effective algorithm bandwidth: 1.06614 GB/s
PCI median bandwidth 6.66009 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0215859 10%=0.02192 median=0.0226666 90%=0.0230744 max=0.0230744)
sum median effective algorithm bandwidth: 16.4352 GB/s
PCI median bandwidth 7.23301 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.0543929 seconds
algorithm times (in seconds) - 10 values (min=0.00236367 10%=0.00236414 median=0.00236471 90%=0.0571074 max=0.0571074)
sum median effective algorithm bandwidth: 157.537 GB/s
PCI median bandwidth 7.42557 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0505684 seconds
algorithm times (in seconds) - 10 values (min=0.00236029 10%=0.00236088 median=0.00236177 90%=0.0532793 max=0.0532793)
sum median effective algorithm bandwidth: 157.733 GB/s
PCI median bandwidth 6.85193 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0903586 seconds
algorithm times (in seconds) - 10 values (min=0.00735638 10%=0.00735719 median=0.0082285 90%=0.0980479 max=0.0980479)
sum median effective algorithm bandwidth: 45.273 GB/s
PCI median bandwidth 7.42509 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0907698 seconds
algorithm times (in seconds) - 10 values (min=0.0303629 10%=0.0308473 median=0.0311221 90%=0.121063 max=0.121063)
sum median effective algorithm bandwidth: 11.9699 GB/s
PCI median bandwidth 7.491 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot
Found 2 GPUs in 0.0441893 sec (CUDA: 7.8908e-05 sec, OpenCL: 0.0202739 sec, Vulkan: 0.0237909 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.0033[8](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:15:9) 10%=2.00338 median=2.00338 [9](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:15:10)0%=2.00338 max=2.00338)
Mandelbrot effective algorithm GFlops: 4.99157 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - [10](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:15:11) values (min=0.601946 10%=0.602133 median=0.609775 90%=0.70927 max=0.70927)
Mandelbrot effective algorithm GFlops: 16.3995 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.[13](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:15:14)9771 seconds
algorithm times (in seconds) - 10 values (min=0.[14](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:15:15)0735 10%=0.140744 median=0.140805 90%=0.28192 max=0.28192)
Mandelbrot effective algorithm GFlops: 71.02 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 2 GPUs in 0.0456792 sec (CUDA: 8.1763e-05 sec, OpenCL: 0.0210348 sec, Vulkan: 0.0245185 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.033024 10%=0.0331141 median=0.0334477 90%=0.033[8](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:9)876 max=0.0338876)
sum median effective algorithm bandwidth: 11.1376 GB/s
PCI median bandwidth 17.1278 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.020[9](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:10)252 10%=0.0209514 median=0.0210995 90%=0.022003 max=0.022003)
sum median effective algorithm bandwidth: 17.6558 GB/s
PCI median bandwidth 16.306 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.[10](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:11)9509 seconds
algorithm times (in seconds) - 10 values (min=1.412 10%=1.41613 median=1.42347 90%=1.52657 max=1.52657)
sum median effective algorithm bandwidth: 0.261705 GB/s
PCI median bandwidth 15.7299 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0293342 seconds
algorithm times (in seconds) - 10 values (min=0.709135 10%=0.709251 median=0.7[11](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:12)107 90%=0.740407 max=0.740407)
sum median effective algorithm bandwidth: 0.523872 GB/s
PCI median bandwidth 15.98 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0462995 seconds
algorithm times (in seconds) - 10 values (min=0.0568868 10%=0.0569306 median=0.0571071 90%=0.103969 max=0.103969)
sum median effective algorithm bandwidth: 6.52334 GB/s
PCI median bandwidth 15.1[12](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:13)6 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0369[14](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:15)5 seconds
algorithm times (in seconds) - 10 values (min=0.265[15](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/18281195625/job/52044500644?pr=281#step:16:16)9 10%=0.265524 median=0.26595 90%=0.304645 max=0.304645)
sum median effective algorithm bandwidth: 1.40075 GB/s
PCI median bandwidth 15.9603 GB/s

</pre>

</p></details>