### PR TITLE
Task02 Игорь Афанасьев HSE

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -16,4 +16,33 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int j = get_global_id(1);
 
     // TODO
+    if (i >= width || j >= height) {
+        return;
+    }
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -15,5 +15,24 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
     // __local uint local_data[GROUP_SIZE];
     // barrier(CLK_LOCAL_MEM_FENCE);
 
-    // TODO
+    __local uint local_data[GROUP_SIZE];
+
+    const uint index = get_global_id(0);
+    const uint group_index = get_local_id(0);
+    if (index >= n) {
+        local_data[group_index] = 0;
+    } else {
+        local_data[group_index] = a[index];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (group_index == 0) {
+        uint local_sum = 0;
+        for (size_t i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        atomic_add(sum, local_sum);
+    }
+
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -18,4 +18,23 @@ __kernel void sum_04_local_reduction(__global const uint* a,
     // barrier(CLK_LOCAL_MEM_FENCE);
 
     // TODO
+    __local uint local_data[GROUP_SIZE];
+
+    const uint index = get_global_id(0);
+    const uint group_index = get_local_id(0);
+    if (index >= n) {
+        local_data[group_index] = 0;
+    } else {
+        local_data[group_index] = a[index];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (group_index == 0) {
+        uint local_sum = 0;
+        for (size_t i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        b[get_group_id(0)] = local_sum;
+    }
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,8 +121,8 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
./main_mandelbrot
Found 1 GPUs in 0.0655499 sec (OpenCL: 0.065306 sec, Vulkan: 0.000226542 sec)
Available devices:
  Device #0: API: OpenCL. GPU. Apple M2. Total memory: 16384 Mb.
Using device #0: API: OpenCL. GPU. Apple M2. Total memory: 16384 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=4.05792 10%=4.05792 median=4.05792 90%=4.05792 max=4.05792)
Mandelbrot effective algorithm GFlops: 2.46432 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x1 threads
algorithm times (in seconds) - 10 values (min=4.11049 10%=4.1105 median=4.13398 90%=4.37738 max=4.37738)
Mandelbrot effective algorithm GFlops: 2.41898 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.00136083 seconds
algorithm times (in seconds) - 10 values (min=0.00654254 10%=0.00654383 median=0.00656942 90%=0.019083 max=0.019083)
Mandelbrot effective algorithm GFlops: 1522.21 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0%
</pre>


<pre>
./main_sum
Found 1 GPUs in 0.0704632 sec (OpenCL: 0.0698986 sec, Vulkan: 0.000543542 sec)
Available devices:
  Device #0: API: OpenCL. GPU. Apple M2. Total memory: 16384 Mb.
Using device #0: API: OpenCL. GPU. Apple M2. Total memory: 16384 Mb.
Using OpenCL API...
median PCI-E bandwith: 23.8692 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0894735 10%=0.0894977 median=0.0895426 90%=0.0926282 max=0.0926282)
sum median effective algorithm bandwidth: 4.16036 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.089101 10%=0.0892398 median=0.089498 90%=0.0910524 max=0.0910524)
sum median effective algorithm bandwidth: 4.16243 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.00156408 seconds
algorithm times (in seconds) - 10 values (min=0.00530204 10%=0.00532017 median=0.00588113 90%=0.0207545 max=0.0207545)
sum median effective algorithm bandwidth: 63.3432 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.000218125 seconds
algorithm times (in seconds) - 10 values (min=0.00456854 10%=0.00459688 median=0.00514946 90%=0.00998867 max=0.00998867)
sum median effective algorithm bandwidth: 72.3433 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.000217417 seconds
algorithm times (in seconds) - 10 values (min=0.00831238 10%=0.00833038 median=0.00838388 90%=0.0190126 max=0.0190126)
sum median effective algorithm bandwidth: 44.434 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.00099475 seconds
algorithm times (in seconds) - 10 values (min=0.00860892 10%=0.00872279 median=0.00873708 90%=0.0198079 max=0.0198079)
sum median effective algorithm bandwidth: 42.6377 GB/s
</pre>

</p></details>



<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./main_mandelbrot 0
Found 2 GPUs in 0.0472071 sec (CUDA: 7.8426e-05 sec, OpenCL: 0.0209714 sec, Vulkan: 0.0261069 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00082 10%=2.00082 median=2.00082 90%=2.00082 max=2.00082)
Mandelbrot effective algorithm GFlops: 4.99794 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.602095 10%=0.602238 median=0.602917 90%=0.776813 max=0.776813)
Mandelbrot effective algorithm GFlops: 16.586 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.154517 seconds
algorithm times (in seconds) - 10 values (min=0.151602 10%=0.151616 median=0.151719 90%=0.307877 max=0.307877)
Mandelbrot effective algorithm GFlops: 65.9112 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%
</pre>


<pre>
Run ./main_sum 0
Found 2 GPUs in 0.0476368 sec (CUDA: 8.558e-05 sec, OpenCL: 0.0219636 sec, Vulkan: 0.0255373 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
median PCI-E bandwith: 13.9596 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0335378 10%=0.0336424 median=0.0338389 90%=0.0347118 max=0.0347118)
sum median effective algorithm bandwidth: 11.0089 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0218497 10%=0.0218559 median=0.0220532 90%=0.0228929 max=0.0228929)
sum median effective algorithm bandwidth: 16.8923 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.111968 seconds
algorithm times (in seconds) - 10 values (min=1.40307 10%=1.40366 median=1.40784 90%=1.51867 max=1.51867)
sum median effective algorithm bandwidth: 0.264611 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0296048 seconds
algorithm times (in seconds) - 10 values (min=0.703879 10%=0.706183 median=0.707027 90%=0.73853 max=0.73853)
sum median effective algorithm bandwidth: 0.526895 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0471091 seconds
algorithm times (in seconds) - 10 values (min=0.0567212 10%=0.0567753 median=0.0568445 90%=0.104587 max=0.104587)
sum median effective algorithm bandwidth: 6.55347 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0365528 seconds
algorithm times (in seconds) - 10 values (min=0.0654665 10%=0.0655166 median=0.0656524 90%=0.103165 max=0.103165)
sum median effective algorithm bandwidth: 5.67426 GB/s
</pre>

</p></details>