### PR TITLE
Task02 Dmitry Kudimov ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,30 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+            
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -9,11 +9,23 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        __global       uint* sum,
                                                        const unsigned int n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    local_data[local_index] = a[index];
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0)
+    {
+        uint my_sum = 0;
+        for (int i = 0; i < GROUP_SIZE; ++i)
+        {
+            my_sum += local_data[i];
+        }
+
+        atomic_add(sum, my_sum);
+    }
+
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -11,11 +11,26 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                      __global       uint* b,
                                             unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n)
+        local_data[local_index] = a[index];
+    else 
+        local_data[local_index] = 0;
+    
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0)
+    {
+        uint my_sum = 0;
+        for (int i = 0; i < GROUP_SIZE; ++i)
+        {
+            my_sum += local_data[i];
+        }
+
+        b[get_group_id(0)] = my_sum;
+    }
+
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -122,7 +122,11 @@ void run(int argc, char** argv)
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
                     // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    // ocl_mandelbrot.exec()
+
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
+                    // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -72,10 +72,21 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u reduction_buffer2_gpu(div_ceil(n, (unsigned int)GROUP_SIZE));
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    input_gpu.writeN(values.data(), n);
-    // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
-    // TODO 2) сделайте замер хотя бы три раза
-    // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    {
+        std::vector<double> pcie_times;
+        for (size_t iter = 0; iter < 20; iter++)
+        {
+            timer t;
+            input_gpu.writeN(values.data(), n);
+            pcie_times.push_back(t.elapsed());
+        }
+        
+        std::cout << "PCI-E transfer times (in seconds) - " << stats::valuesStatsLine(pcie_times) << std::endl;
+        const double memory_size_gb = sizeof(unsigned int) * n / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "PCI-E effective bandwidth: " << memory_size_gb / stats::median(pcie_times) << " GB/s" << std::endl;
+    }
+    
+
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -113,11 +124,26 @@ void run(int argc, char** argv)
                         ocl_sum02AtomicsLoadK.exec(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO ocl_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        reduction_buffer1_gpu.fill(0);
+                        reduction_buffer2_gpu.fill(0);
+
+                        auto current_work_size = n; 
+                        ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, current_work_size), input_gpu, reduction_buffer1_gpu, current_work_size);
+                        current_work_size = div_ceil(n, (unsigned int)GROUP_SIZE);
+
+                        while (current_work_size > 1)
+                        {
+                            ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, current_work_size), reduction_buffer1_gpu, reduction_buffer2_gpu, current_work_size);
+                            
+                            current_work_size = div_ceil(current_work_size, (unsigned int)GROUP_SIZE);
+
+                            reduction_buffer1_gpu.swap(reduction_buffer2_gpu);
+                        }
+                        reduction_buffer1_gpu.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
kudiko@kudiko-laptop:~/git/GPGPUTasks2025/build$ ./main_mandelbrot 0
Found 3 GPUs in 0.0716019 sec (OpenCL: 0.0219857 sec, Vulkan: 0.0495668 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 11th Gen Intel(R) Core(TM) i5-1155G7 @ 2.50GHz. Intel(R) Corporation. Total memory: 15731 Mb.
  Device #1: API: Vulkan. iGPU. Intel(R) Xe Graphics (TGL GT2). Free memory: 4906/11798 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15731/15731 Mb.
Using device #0: API: OpenCL. CPU. 11th Gen Intel(R) Core(TM) i5-1155G7 @ 2.50GHz. Intel(R) Corporation. Total memory: 15731 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=3.00031 10%=3.00031 median=3.00031 90%=3.00031 max=3.00031)
Mandelbrot effective algorithm GFlops: 3.33299 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x8 threads
algorithm times (in seconds) - 10 values (min=0.577861 10%=0.594354 median=0.600379 90%=0.620932 max=0.620932)
Mandelbrot effective algorithm GFlops: 16.6561 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.124179 seconds
algorithm times (in seconds) - 10 values (min=0.0430989 10%=0.0431284 median=0.0435617 90%=0.175975 max=0.175975)
Mandelbrot effective algorithm GFlops: 229.559 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

kudiko@kudiko-laptop:~/git/GPGPUTasks2025/build$ ./main_sum 0
Found 3 GPUs in 0.0490026 sec (OpenCL: 0.0219048 sec, Vulkan: 0.0270499 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 11th Gen Intel(R) Core(TM) i5-1155G7 @ 2.50GHz. Intel(R) Corporation. Total memory: 15731 Mb.
  Device #1: API: Vulkan. iGPU. Intel(R) Xe Graphics (TGL GT2). Free memory: 4807/11798 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15731/15731 Mb.
Using device #0: API: OpenCL. CPU. 11th Gen Intel(R) Core(TM) i5-1155G7 @ 2.50GHz. Intel(R) Corporation. Total memory: 15731 Mb.
Using OpenCL API...
PCI-E transfer times (in seconds) - 20 values (min=0.0483527 10%=0.0492253 median=0.0537874 90%=0.0617046 max=0.0696267)
PCI-E effective bandwidth: 6.92596 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.194424 10%=0.199502 median=0.217334 90%=0.248608 max=0.248608)
sum median effective algorithm bandwidth: 1.71408 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0336723 10%=0.0337221 median=0.0403481 90%=0.0549863 max=0.0549863)
sum median effective algorithm bandwidth: 9.23287 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.11159 seconds
algorithm times (in seconds) - 10 values (min=1.97145 10%=1.97576 median=2.0151 90%=2.12684 max=2.12684)
sum median effective algorithm bandwidth: 0.184868 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0414238 seconds
algorithm times (in seconds) - 10 values (min=1.03558 10%=1.03765 median=1.07489 90%=1.16887 max=1.16887)
sum median effective algorithm bandwidth: 0.346574 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0450125 seconds
algorithm times (in seconds) - 10 values (min=0.0296039 10%=0.0296477 median=0.0308686 90%=0.0849679 max=0.0849679)
sum median effective algorithm bandwidth: 12.0682 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0437588 seconds
algorithm times (in seconds) - 10 values (min=0.029401 10%=0.029548 median=0.0310661 90%=0.0862771 max=0.0862771)
sum median effective algorithm bandwidth: 11.9915 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./main_mandelbrot 0
Found 2 GPUs in 0.0450564 sec (CUDA: 7.9689e-05 sec, OpenCL: 0.0201337 sec, Vulkan: 0.0247999 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=1.99985 10%=1.99985 median=1.99985 90%=1.99985 max=1.99985)
Mandelbrot effective algorithm GFlops: 5.00036 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.607426 10%=0.607691 median=0.633074 90%=0.748954 max=0.748954)
Mandelbrot effective algorithm GFlops: 15.7959 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.161674 seconds
algorithm times (in seconds) - 10 values (min=0.149351 10%=0.149392 median=0.149464 90%=0.312953 max=0.312953)
Mandelbrot effective algorithm GFlops: 66.9055 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

Run ./main_sum 0
Found 2 GPUs in 0.045255 sec (CUDA: 0.000102341 sec, OpenCL: 0.0202328 sec, Vulkan: 0.0248751 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCI-E transfer times (in seconds) - 20 values (min=0.0220318 10%=0.0221205 median=0.0224915 90%=0.0232474 max=0.0273935)
PCI-E effective bandwidth: 16.5631 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0334148 10%=0.0334448 median=0.0337135 90%=0.0343406 max=0.0343406)
sum median effective algorithm bandwidth: 11.0498 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0209503 10%=0.0210005 median=0.0211612 90%=0.0218568 max=0.0218568)
sum median effective algorithm bandwidth: 17.6044 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.113443 seconds
algorithm times (in seconds) - 10 values (min=1.558 10%=1.5623 median=1.56579 90%=1.67791 max=1.67791)
sum median effective algorithm bandwidth: 0.237918 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0291735 seconds
algorithm times (in seconds) - 10 values (min=0.783235 10%=0.7835 median=0.784725 90%=0.814549 max=0.814549)
sum median effective algorithm bandwidth: 0.474726 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0495125 seconds
algorithm times (in seconds) - 10 values (min=0.0492191 10%=0.0492276 median=0.0493871 90%=0.0993961 max=0.0993961)
sum median effective algorithm bandwidth: 7.54304 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0378838 seconds
algorithm times (in seconds) - 10 values (min=0.0657453 10%=0.0658265 median=0.0659886 90%=0.106302 max=0.106302)
sum median effective algorithm bandwidth: 5.64535 GB/s
</pre>

</p></details>
