### PR TITLE
Task02 Alina Badakhova HSE

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,34 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    if (i >= width || j >= height) {
+        return;
+    }
+
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    unsigned int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -9,11 +9,20 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        __global       uint* sum,
                                                        const unsigned int n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
-
-    // TODO
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (local_index == 0) {
+        uint masterThreadSum = 0;
+        for (size_t i = 0; i < GROUP_SIZE; ++i) {
+            masterThreadSum += local_data[i];
+        }
+        atomic_add(sum, masterThreadSum);
+    }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -11,11 +11,22 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                      __global       uint* b,
                                             unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    const uint group_index  = get_group_id(0);
+    __local uint local_data[GROUP_SIZE];
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
 
-    // TODO
+    if (local_index == 0) {
+        uint masterThreadSum = 0;
+        for (size_t i = 0; i < GROUP_SIZE; ++i) {
+            masterThreadSum += local_data[i];
+        }
+        b[group_index] =  masterThreadSum;
+    }
 }

--- a/src/kernels/vk/aplusb.comp
+++ b/src/kernels/vk/aplusb.comp
@@ -30,7 +30,7 @@ void main()
 		// (обратите внимание что common.vk так же требует необходимое расширение: #extension GL_EXT_debug_printf : enable)
 		// Необзодимо чтобы validation layers были включены, иначе debugPrintfEXT не заработает
 		#if DEBUG_PRINTF_EXT_ENABLED
-		printf("Vulkan debugPrintfEXT test in aplusb.comp kernel! a[index]=%d b[index]=%d \n", a[index], b[index]);
+		// printf("Vulkan debugPrintfEXT test in aplusb.comp kernel! a[index]=%d b[index]=%d \n", as[index], bs[index]);
 		#endif
 	}
 

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,9 +121,10 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
+                    int num_groups_x = (width + (GROUP_SIZE_X - 1)) / GROUP_SIZE_X;
+                    int num_groups_y = (height + (GROUP_SIZE_Y - 1)) / GROUP_SIZE_Y;
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, num_groups_x * GROUP_SIZE_X, num_groups_y * GROUP_SIZE_Y);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height,centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
                     // TODO cuda::mandelbrot(..);


### PR DESCRIPTION


<details><summary>Локальный вывод</summary><p>

<pre>
htual@htual-osx build % ./main_mandelbrot 
Found 1 GPUs in 0.0884468 sec (OpenCL: 0.0881823 sec, Vulkan: 0.000247167 sec)
Available devices:
  Device #0: API: OpenCL. GPU. Apple M2 Pro. Total memory: 10922 Mb.
Using device #0: API: OpenCL. GPU. Apple M2 Pro. Total memory: 10922 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=4.06398 10%=4.06398 median=4.06398 90%=4.06398 max=4.06398)
Mandelbrot effective algorithm GFlops: 2.46064 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x1 threads
algorithm times (in seconds) - 10 values (min=3.99053 10%=4.00132 median=4.09185 90%=4.4237 max=4.4237)
Mandelbrot effective algorithm GFlops: 2.44388 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.00820546 seconds
algorithm times (in seconds) - 10 values (min=0.00413308 10%=0.00413554 median=0.00416138 90%=0.0386611 max=0.0386611)
Mandelbrot effective algorithm GFlops: 2403.05 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0%

htual@htual-osx build % ./main_sum
Found 1 GPUs in 0.148613 sec (OpenCL: 0.148211 sec, Vulkan: 0.000386625 sec)
Available devices:
  Device #0: API: OpenCL. GPU. Apple M2 Pro. Total memory: 10922 Mb.
Using device #0: API: OpenCL. GPU. Apple M2 Pro. Total memory: 10922 Mb.
Using OpenCL API...
PCI-E bandwidth (median of 3 runs): 23.0629 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0874368 10%=0.0875643 median=0.0883848 90%=0.0965692 max=0.0965692)
sum median effective algorithm bandwidth: 4.21485 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0861879 10%=0.087176 median=0.0883673 90%=0.096781 max=0.096781)
sum median effective algorithm bandwidth: 4.21569 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.00202171 seconds
algorithm times (in seconds) - 10 values (min=0.00339025 10%=0.00340258 median=0.00343167 90%=0.0122674 max=0.0122674)
sum median effective algorithm bandwidth: 108.556 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.000301833 seconds
algorithm times (in seconds) - 10 values (min=0.00245733 10%=0.00246167 median=0.00286292 90%=0.00691008 max=0.00691008)
sum median effective algorithm bandwidth: 130.122 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.000250458 seconds
algorithm times (in seconds) - 10 values (min=0.00539179 10%=0.00541288 median=0.00546438 90%=0.0163836 max=0.0163836)
sum median effective algorithm bandwidth: 68.1741 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.000224958 seconds
algorithm times (in seconds) - 10 values (min=0.0275469 10%=0.0275931 median=0.0278488 90%=0.0378895 max=0.0378895)
sum median effective algorithm bandwidth: 13.3768 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./main_mandelbrot 0
Found 2 GPUs in 0.0443467 sec (CUDA: 8.05e-05 sec, OpenCL: 0.0199491 sec, Vulkan: 0.0242751 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00378 10%=2.00378 median=2.00378 90%=2.00378 max=2.00378)
Mandelbrot effective algorithm GFlops: 4.99056 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.60711 10%=0.607121 median=0.608001 90%=0.771777 max=0.771777)
Mandelbrot effective algorithm GFlops: 16.4474 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.16165 seconds
algorithm times (in seconds) - 10 values (min=0.149527 10%=0.149551 median=0.1497 90%=0.312768 max=0.312768)
Mandelbrot effective algorithm GFlops: 66.8004 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

Run ./main_sum 0
Found 2 GPUs in 0.0448061 sec (CUDA: 8.025e-05 sec, OpenCL: 0.0201923 sec, Vulkan: 0.0244913 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCI-E bandwidth (median of 3 runs): 16.7957 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0328155 10%=0.0328476 median=0.0330145 90%=0.0336104 max=0.0336104)
sum median effective algorithm bandwidth: 11.2838 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0207992 10%=0.0208176 median=0.0210283 90%=0.0221106 max=0.0221106)
sum median effective algorithm bandwidth: 17.7156 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.11129 seconds
algorithm times (in seconds) - 10 values (min=1.36743 10%=1.36848 median=1.36991 90%=1.47742 max=1.47742)
sum median effective algorithm bandwidth: 0.271937 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0291754 seconds
algorithm times (in seconds) - 10 values (min=0.687424 10%=0.687572 median=0.688189 90%=0.714941 max=0.714941)
sum median effective algorithm bandwidth: 0.541318 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0452812 seconds
algorithm times (in seconds) - 10 values (min=0.0564709 10%=0.0564882 median=0.0565654 90%=0.102291 max=0.102291)
sum median effective algorithm bandwidth: 6.58581 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0362918 seconds
algorithm times (in seconds) - 10 values (min=0.065922 10%=0.0659512 median=0.0661219 90%=0.104929 max=0.104929)
sum median effective algorithm bandwidth: 5.63397 GB/s
</pre>

</p></details>