### PR TITLE
Task03 Леонид Альжанов ITMO

### DIFF
--- a/src/kernels/cl/matrix_01_transpose_naive.cl
+++ b/src/kernels/cl/matrix_01_transpose_naive.cl
@@ -4,12 +4,14 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
 __kernel void matrix_01_transpose_naive(
                        __global const float* matrix,            // w x h
                        __global       float* transposed_matrix, // h x w
                                 unsigned int w,
                                 unsigned int h)
 {
-    // TODO
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    transposed_matrix[x * h + y] = matrix[y * w + x];
 }

--- a/src/kernels/cl/matrix_02_transpose_coalesced_via_local_memory.cl
+++ b/src/kernels/cl/matrix_02_transpose_coalesced_via_local_memory.cl
@@ -4,12 +4,26 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+#define LOCAL_WIDTH (GROUP_SIZE_X + 1)
+#define LOCAL_HEIGHT GROUP_SIZE_Y
+
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_02_transpose_coalesced_via_local_memory(
                        __global const float* matrix,            // w x h
                        __global       float* transposed_matrix, // h x w
                                 unsigned int w,
                                 unsigned int h)
 {
-    // TODO
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    const unsigned int local_x = get_local_id(0);
+    const unsigned int local_y = get_local_id(1);
+    __local float local_data[LOCAL_WIDTH * LOCAL_HEIGHT];
+    const unsigned int index = y * w + x;
+    local_data[local_y * LOCAL_WIDTH + local_x] = index < w * h ? matrix[index] : 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const unsigned int new_x = y - local_y + local_x;
+    const unsigned int new_y = x - local_x + local_y;
+    transposed_matrix[new_y * h + new_x] = local_data[local_x * LOCAL_WIDTH + local_y];
 }

--- a/src/kernels/cl/matrix_03_multiply_naive.cl
+++ b/src/kernels/cl/matrix_03_multiply_naive.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_03_multiply_naive(
                        __global const float* a, // rows=h x cols=k
                        __global const float* b, // rows=k x cols=w
@@ -13,5 +13,14 @@ __kernel void matrix_03_multiply_naive(
                                 unsigned int h,
                                 unsigned int k)
 {
-    // TODO
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    float sum = 0;
+    for (unsigned int z = 0; z < k; ++z) {
+        sum += a[y * k + z] * b[z * w + x];
+        //if (x == 0 && y == 0 && z < 16) {
+        //    printf("%f %f", a[y * k + z], b[z * w + x]);
+        //}
+    }
+    c[y * w + x] = sum;
 }

--- a/src/kernels/cl/matrix_04_multiply_via_local_memory.cl
+++ b/src/kernels/cl/matrix_04_multiply_via_local_memory.cl
@@ -4,7 +4,11 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+#define BLOCK_DIM GROUP_SIZE_X // GROUP_SIZE_X has to be equal to GROUP_SIZE_Y
+#define LOCAL_WIDTH (BLOCK_DIM + 1)
+#define LOCAL_HEIGHT BLOCK_DIM
+
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_04_multiply_via_local_memory(
                        __global const float* a, // rows=h x cols=k
                        __global const float* b, // rows=k x cols=w
@@ -13,5 +17,31 @@ __kernel void matrix_04_multiply_via_local_memory(
                                 unsigned int h,
                                 unsigned int k)
 {
-    // TODO
+    const unsigned int x = get_global_id(0);
+    const unsigned int y = get_global_id(1);
+    const unsigned int local_x = get_local_id(0);
+    const unsigned int local_y = get_local_id(1);
+    __local float a_chunk[LOCAL_WIDTH * LOCAL_HEIGHT];
+    __local float b_chunk[LOCAL_WIDTH * LOCAL_HEIGHT];
+    const unsigned int chunk_address = local_y * LOCAL_WIDTH + local_x;
+
+    float sum = 0;
+    for (unsigned int block = 0; block * BLOCK_DIM < k; block++) {
+        unsigned int z = block * BLOCK_DIM + local_x;
+        a_chunk[chunk_address] = z < k ? a[k * y + z] : 0;
+        z = block * BLOCK_DIM + local_y;
+        b_chunk[chunk_address] = z < k ? b[w * z + x] : 0;
+        barrier(CLK_LOCAL_MEM_FENCE);
+        for (z = 0; z < BLOCK_DIM; z++){
+            //if (x == 0 && y == 0 && block == 0) {
+            //    printf("%f %f", a_chunk[local_y * LOCAL_WIDTH + z], b_chunk[z * LOCAL_WIDTH + local_x]);
+            //}
+            sum += a_chunk[local_y * LOCAL_WIDTH + z] * b_chunk[z * LOCAL_WIDTH + local_x];
+        }
+        //if (x == 0 && y == 0) {
+        //    printf("\n");
+        //}
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+    c[y * w + x] = sum;
 }

--- a/src/main_01_matrix_transpose.cpp
+++ b/src/main_01_matrix_transpose.cpp
@@ -68,13 +68,13 @@ void run(int argc, char** argv)
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
 
-            throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED); // TODO remove me
+            // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED); // TODO remove me
             // _______________________________OpenCL_____________________________________________
             if (context.type() == gpu::Context::TypeOpenCL) {
                 if (algorithm == "01 naive transpose (non-coalesced)") {
-                    ocl_matrix01TransposeNaive.exec(gpu::WorkSize(1, 1, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
+                    ocl_matrix01TransposeNaive.exec(gpu::WorkSize(GROUP_SIZE, 1, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
                 } else if (algorithm == "02 transpose via local memory (coalesced)") {
-                    ocl_matrix02TransposeCoalescedViaLocalMemory.exec(gpu::WorkSize(1, 1, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
+                    ocl_matrix02TransposeCoalescedViaLocalMemory.exec(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
                 } else {
                     rassert(false, 652345234321, algorithm, algorithm_index);
                 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_matrix_transpose 1
Found 3 GPUs in 0.0662033 sec (OpenCL: 0.0316613 sec, Vulkan: 0.0344989 sec)
Available devices:
  Device #0: API: Vulkan. iGPU. AMD Radeon 680M (RADV REMBRANDT). Free memory: 5407/5596 Mb.
  Device #1: API: OpenCL. GPU. AMD Radeon 680M (gfx1035). Free memory: 7337/7370 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 19.1.7, 256 bits). Free memory: 14741/14741 Mb.
Using device #1: API: OpenCL. GPU. AMD Radeon 680M (gfx1035). Free memory: 7337/7370 Mb.
Using OpenCL API...
Matrix size: rows=H=8192 x cols=W=16384 (512 MB)
______________________________________________________
Evaluating algorithm #1/2: 01 naive transpose (non-coalesced)
Kernels compilation done in 0.0718452 seconds
algorithm times (in seconds) - 10 values (min=1.1146 10%=1.11471 median=1.11772 90%=1.19002 max=1.19002)
median effective algorithm bandwidth: 0.894681 GB/s
______________________________________________________
Evaluating algorithm #2/2: 02 transpose via local memory (coalesced)
Kernels compilation done in 0.0780301 seconds
algorithm times (in seconds) - 10 values (min=0.0531683 10%=0.0531943 median=0.053332 90%=0.163131 max=0.163131)
median effective algorithm bandwidth: 18.7505 GB/s
$ ./main_matrix_multiply 1
Found 3 GPUs in 0.0691668 sec (OpenCL: 0.0337356 sec, Vulkan: 0.0353965 sec)
Available devices:
  Device #0: API: Vulkan. iGPU. AMD Radeon 680M (RADV REMBRANDT). Free memory: 5400/5596 Mb.
  Device #1: API: OpenCL. GPU. AMD Radeon 680M (gfx1035). Free memory: 7346/7370 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 19.1.7, 256 bits). Free memory: 14741/14741 Mb.
Using device #1: API: OpenCL. GPU. AMD Radeon 680M (gfx1035). Free memory: 7346/7370 Mb.
Using OpenCL API...
C = A x B, matrices size: C (rows=H=2048 x cols=W=4096) = A (rows=H=2048 x cols=K=1024) x B (rows=K=1024 x cols=W=4096)
matrices data size: A - 8 MB, B - 16 MB, C - 16 MB
______________________________________________________
Evaluating algorithm #1/3: CPU with OpenMP
algorithm times (in seconds) - 1 values (min=5.42964 10%=5.42964 median=5.42964 90%=5.42964 max=5.42964)
algorithm GFlops: 3.16255 GFlops
algorithm effective memory bandwidth: 0.010072 GB/s
______________________________________________________
Evaluating algorithm #2/3: 01 naive
Kernels compilation done in 0.085628 seconds
algorithm times (in seconds) - 10 values (min=0.275778 10%=0.275976 median=0.279164 90%=0.391815 max=0.391815)
algorithm GFlops: 61.5103 GFlops
algorithm effective memory bandwidth: 0.195897 GB/s
relative differences with CPU: 8388608 values (min=0 10%=0 median=2.21073e-07 90%=1.12363e-06 max=2.77294)
median relative difference with CPU: 2.21073e-07
99% percentile relative difference with CPU: 1.09303e-05
______________________________________________________
Evaluating algorithm #3/3: 02 using local memory
Kernels compilation done in 0.0898477 seconds
algorithm times (in seconds) - 10 values (min=0.093659 10%=0.0942892 median=0.0970725 90%=0.213972 max=0.213972)
algorithm GFlops: 176.893 GFlops
algorithm effective memory bandwidth: 0.563367 GB/s
relative differences with CPU: 8388608 values (min=0 10%=0 median=2.21073e-07 90%=1.12363e-06 max=2.77294)
median relative difference with CPU: 2.21073e-07
99% percentile relative difference with CPU: 1.09303e-05
</pre>

</p></details>
<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_matrix_transpose 0
Found 2 GPUs in 0.0465069 sec (CUDA: 8.1542e-05 sec, OpenCL: 0.0208851 sec, Vulkan: 0.0254932 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
Matrix size: rows=H=8192 x cols=W=16384 (512 MB)
______________________________________________________
Evaluating algorithm #1/2: 01 naive transpose (non-coalesced)
Kernels compilation done in 0.123107 seconds
algorithm times (in seconds) - 10 values (min=0.508238 10%=0.512017 median=0.522589 90%=0.708617 max=0.708617)
median effective algorithm bandwidth: 1.91355 GB/s
______________________________________________________
Evaluating algorithm #2/2: 02 transpose via local memory (coalesced)
Kernels compilation done in 0.0428333 seconds
algorithm times (in seconds) - 10 values (min=0.150254 10%=0.150436 median=0.150519 90%=0.194371 max=0.194371)
median effective algorithm bandwidth: 6.64368 GB/s

$ ./main_matrix_multiply 0
Found 2 GPUs in 0.0487652 sec (CUDA: 8.8836e-05 sec, OpenCL: 0.0223094 sec, Vulkan: 0.0263156 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
C = A x B, matrices size: C (rows=H=2048 x cols=W=4096) = A (rows=H=2048 x cols=K=1024) x B (rows=K=1024 x cols=W=4096)
matrices data size: A - 8 MB, B - 16 MB, C - 16 MB
______________________________________________________
Evaluating algorithm #1/3: CPU with OpenMP
algorithm times (in seconds) - 1 values (min=17.7155 10%=17.7155 median=17.7155 90%=17.7155 max=17.7155)
algorithm GFlops: 0.969291 GFlops
algorithm effective memory bandwidth: 0.00308698 GB/s
______________________________________________________
Evaluating algorithm #2/3: 01 naive
Kernels compilation done in 0.122285 seconds
algorithm times (in seconds) - 10 values (min=1.90661 10%=1.91088 median=2.01093 90%=2.20832 max=2.20832)
algorithm GFlops: 8.53908 GFlops
algorithm effective memory bandwidth: 0.0271951 GB/s
relative differences with CPU: 8388608 values (min=0 10%=0 median=2.21073e-07 90%=1.12363e-06 max=2.77294)
median relative difference with CPU: 2.21073e-07
99% percentile relative difference with CPU: 1.09303e-05
______________________________________________________
Evaluating algorithm #3/3: 02 using local memory
Kernels compilation done in 0.0712619 seconds
algorithm times (in seconds) - 10 values (min=2.19207 10%=2.19498 median=2.1998 90%=2.27058 max=2.27058)
algorithm GFlops: 7.80593 GFlops
algorithm effective memory bandwidth: 0.0248602 GB/s
relative differences with CPU: 8388608 values (min=0 10%=0 median=2.21073e-07 90%=1.12363e-06 max=2.77294)
median relative difference with CPU: 2.21073e-07
99% percentile relative difference with CPU: 1.09303e-05
</pre>

</p></details>