### PR TITLE
Task02 Дарья Фомина HSE

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,34 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    if (i >= width || j >= height) {
+        return;
+    };
+
+    const float threshold  = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    unsigned int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if (x * x + y * y > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    int idx = j * width + i;
+    results[idx] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -15,5 +15,30 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
     // __local uint local_data[GROUP_SIZE];
     // barrier(CLK_LOCAL_MEM_FENCE);
 
-    // TODO
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    const uint size = get_global_size(0);
+    const uint local_size = get_local_size(0);
+
+    __local uint local_data[GROUP_SIZE];
+
+    uint part_sum = 0;
+    for (uint idx = index; idx < n; idx += size) {
+        part_sum += a[idx];
+    }
+    local_data[local_index] = part_sum;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // я здесь попробовала сделать так, чтобы на каждом шаге потоки работали по парам и на каждом шаге сокращаем количество работающих потоков
+    // у меня это получилось эффективнее, чем 1 мастер тред все складывает, но здесь барьер дорогой
+    for (uint step = local_size / 2; step > 0; step = step / 2) {
+        if (local_index < step) {
+            local_data[local_index] += local_data[local_index + step];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (local_index == 0) { // мастер-поток
+        atom_add(sum, local_data[0]);
+    }
 }

--- a/src/kernels/vk/aplusb.comp
+++ b/src/kernels/vk/aplusb.comp
@@ -30,7 +30,7 @@ void main()
 		// (обратите внимание что common.vk так же требует необходимое расширение: #extension GL_EXT_debug_printf : enable)
 		// Необзодимо чтобы validation layers были включены, иначе debugPrintfEXT не заработает
 		#if DEBUG_PRINTF_EXT_ENABLED
-		printf("Vulkan debugPrintfEXT test in aplusb.comp kernel! a[index]=%d b[index]=%d \n", a[index], b[index]);
+		debugPrintfEXT("Vulkan debugPrintfEXT test in aplusb.comp kernel! as[index]=%d bs[index]=%d \n", as[index], bs[index]);
 		#endif
 	}
 

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,8 +121,14 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    const unsigned int lx = GROUP_SIZE_X;
+                    const unsigned int ly = GROUP_SIZE_Y;
+                    const unsigned int round_width = ((width + lx - 1) / lx) * lx;
+                    const unsigned int round_height = ((height + ly - 1) / ly) * ly;
+                    gpu::WorkSize workSize(lx, ly, round_width, round_height);
+
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,sizeX, sizeY, iterationsLimit, isSmoothing);
+
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
sinfillo@172 build % ./main_mandelbrot
Found 1 GPUs in 0.052107 sec (OpenCL: 0.0448712 sec, Vulkan: 0.00720808 sec)
Available devices:
  Device #0: API: OpenCL+Vulkan. GPU. Apple M3 Pro. Free memory: 27648/27648 Mb.
Using device #0: API: OpenCL+Vulkan. GPU. Apple M3 Pro. Free memory: 27648/27648 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.96011 10%=2.96011 median=2.96011 90%=2.96011 max=2.96011)
Mandelbrot effective algorithm GFlops: 3.37825 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x1 threads
algorithm times (in seconds) - 10 values (min=2.80002 10%=2.88062 median=2.96348 90%=3.02011 max=3.02011)
Mandelbrot effective algorithm GFlops: 3.37441 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.038426 seconds
algorithm times (in seconds) - 10 values (min=0.00283838 10%=0.00286217 median=0.00331196 90%=0.0926379 max=0.0926379)
Mandelbrot effective algorithm GFlops: 3019.36 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0%
sinfillo@172 build % ./main_sum
Found 1 GPUs in 0.0538838 sec (OpenCL: 0.0466543 sec, Vulkan: 0.00720558 sec)
Available devices:
  Device #0: API: OpenCL+Vulkan. GPU. Apple M3 Pro. Free memory: 27648/27648 Mb.
Using device #0: API: OpenCL+Vulkan. GPU. Apple M3 Pro. Free memory: 27648/27648 Mb.
Using OpenCL API...
PCIe write times (s): 3 values (min=0.0123366 10%=0.0123366 median=0.0129578 90%=0.0140093 max=0.0140093)
PCIe effective bandwidth: 28.7493 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.07425 10%=0.0742538 median=0.0752754 90%=0.0797543 max=0.0797543)
sum median effective algorithm bandwidth: 4.94888 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0742118 10%=0.0742161 median=0.0743068 90%=0.0746736 max=0.0746736)
sum median effective algorithm bandwidth: 5.01339 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.000546125 seconds
algorithm times (in seconds) - 10 values (min=0.00508892 10%=0.005167 median=0.00522192 90%=0.0130286 max=0.0130286)
sum median effective algorithm bandwidth: 71.3395 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.000198833 seconds
algorithm times (in seconds) - 10 values (min=0.00316517 10%=0.00321308 median=0.00328779 90%=0.00779842 max=0.00779842)
sum median effective algorithm bandwidth: 113.307 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.02534 seconds
algorithm times (in seconds) - 10 values (min=0.00990225 10%=0.0099085 median=0.00995017 90%=0.0814245 max=0.0814245)
sum median effective algorithm bandwidth: 37.4395 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0053415 seconds
algorithm times (in seconds) - 10 values (min=0.0102161 10%=0.0103082 median=0.0103379 90%=0.029786 max=0.029786)
sum median effective algorithm bandwidth: 36.0352 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
Run ./main_mandelbrot 0
Found 2 GPUs in 0.0452377 sec (CUDA: 8.1943e-05 sec, OpenCL: 0.0205357 sec, Vulkan: 0.0245736 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00048 10%=2.00048 median=2.00048 90%=2.00048 max=2.00048)
Mandelbrot effective algorithm GFlops: 4.99879 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.602159 10%=0.602197 median=0.603362 90%=0.796042 max=0.796042)
Mandelbrot effective algorithm GFlops: 16.5738 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.155175 seconds
algorithm times (in seconds) - 10 values (min=0.150577 10%=0.150625 median=0.150727 90%=0.307335 max=0.307335)
Mandelbrot effective algorithm GFlops: 66.3451 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%
Run ./main_sum 0
Found 2 GPUs in 0.0462856 sec (CUDA: 8.7894e-05 sec, OpenCL: 0.021314 sec, Vulkan: 0.0248312 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCIe write times (s): 3 values (min=0.0232987 10%=0.0232987 median=0.0236664 90%=0.0240507 max=0.0240507)
PCIe effective bandwidth: 15.7409 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0325744 10%=0.0326684 median=0.0327318 90%=0.0335671 max=0.0335671)
sum median effective algorithm bandwidth: 11.3812 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0213638 10%=0.0214251 median=0.0215345 90%=0.0225915 max=0.0225915)
sum median effective algorithm bandwidth: 17.2992 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.111309 seconds
algorithm times (in seconds) - 10 values (min=1.46411 10%=1.46411 median=1.46712 90%=1.57783 max=1.57783)
sum median effective algorithm bandwidth: 0.253919 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.029336 seconds
algorithm times (in seconds) - 10 values (min=0.732668 10%=0.734968 median=0.736456 90%=0.765472 max=0.765472)
sum median effective algorithm bandwidth: 0.50584 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0567396 seconds
algorithm times (in seconds) - 10 values (min=0.521573 10%=0.521653 median=0.522301 90%=0.57895 max=0.57895)
sum median effective algorithm bandwidth: 0.713246 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0457057 seconds
algorithm times (in seconds) - 10 values (min=0.505155 10%=0.505331 median=0.506253 90%=0.553075 max=0.553075)
sum median effective algorithm bandwidth: 0.735855 GB/s
</pre>

</p></details>