### PR TITLE
Task02 Патрушев Александр ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,36 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    const float threshold = 256.0;
+    const float threshold2 = threshold * threshold;
+
+    if (i >= width || j >= height)
+        return;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    uint iter = 0;
+
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+
+    float result = iter;
+
+    if (isSmoothing != 0 && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/vk/aplusb.comp
+++ b/src/kernels/vk/aplusb.comp
@@ -1,4 +1,5 @@
 #version 450
+#extension GL_EXT_debug_printf : enable
 
 #include <libgpu/vulkan/vk/common.vk>
 
@@ -30,7 +31,7 @@ void main()
 		// (обратите внимание что common.vk так же требует необходимое расширение: #extension GL_EXT_debug_printf : enable)
 		// Необзодимо чтобы validation layers были включены, иначе debugPrintfEXT не заработает
 		#if DEBUG_PRINTF_EXT_ENABLED
-		printf("Vulkan debugPrintfEXT test in aplusb.comp kernel! a[index]=%d b[index]=%d \n", a[index], b[index]);
+		debugPrintfEXT("Vulkan debugPrintfEXT test in aplusb.comp kernel! as[index]=%d bs[index]=%d \n", as[index], bs[index]);
 		#endif
 	}
 

--- a/src/kernels/vk/sum_03_local_memory_atomic_per_workgroup.comp
+++ b/src/kernels/vk/sum_03_local_memory_atomic_per_workgroup.comp
@@ -13,7 +13,7 @@ layout (push_constant) uniform PushConstants {
 
 layout (local_size_x = GROUP_SIZE) in;
 
-// shared uint local_data[GROUP_SIZE];
+shared uint local_data[GROUP_SIZE];
 
 void main()
 {
@@ -24,5 +24,30 @@ void main()
     // memoryBarrierShared();
     // barrier();
 
-    // TODO
-}
+    // TODO done
+
+    const uint index = gl_GlobalInvocationID.x;
+    const uint local_index = gl_LocalInvocationID.x;
+
+    if (index >= params.n / LOAD_K_VALUES_PER_ITEM) {
+        return;
+    }
+
+    local_data[local_index] = 0;
+
+    for (uint i = 0; i < LOAD_K_VALUES_PER_ITEM; ++i) {
+        local_data[local_index] += a[i * (params.n/LOAD_K_VALUES_PER_ITEM) + index];
+    }
+
+    memoryBarrierShared();
+    barrier();
+
+    if (local_index == 0) {
+        uint group_sum = 0;
+        uint threads_in_group = min(GROUP_SIZE, params.n / LOAD_K_VALUES_PER_ITEM - gl_WorkGroupID.x * GROUP_SIZE);
+        for (uint i = 0; i < threads_in_group; i++) {
+            group_sum += local_data[i];
+        }
+        atomicAdd(sum[0], group_sum);
+    }
+}

--- a/src/kernels/vk/sum_04_local_reduction.comp
+++ b/src/kernels/vk/sum_04_local_reduction.comp
@@ -15,7 +15,7 @@ layout (push_constant) uniform PushConstants {
 
 layout (local_size_x = GROUP_SIZE) in;
 
-// shared uint local_data[GROUP_SIZE];
+shared uint local_data[GROUP_SIZE];
 
 void main()
 {
@@ -26,5 +26,25 @@ void main()
     // memoryBarrierShared();
     // barrier();
 
-    // TODO
+    // TODO done
+
+    const uint index = gl_GlobalInvocationID.x;
+    const uint local_index = gl_LocalInvocationID.x;
+    const uint group_index  = gl_WorkGroupID.x;
+
+    uint value = 0;
+    if (index < params.n) {
+        value = a[index];
+    }
+
+    local_data[local_index] = value;
+    barrier();
+
+    if (local_index == 0) {
+        uint block_sum = 0;
+        for (uint k = 0; k < GROUP_SIZE; ++k) {
+            block_sum += local_data[k];
+        }
+        b[group_index] = block_sum;
+    }
 }

--- a/src/main_aplusb.cpp
+++ b/src/main_aplusb.cpp
@@ -23,7 +23,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeVulkan);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -112,6 +112,8 @@ void run(int argc, char** argv)
         for (int iter = 0; iter < iters_count; ++iter) {
             timer t;
 
+            gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);       
+
             if (algorithm == "CPU") {
                 cpu::mandelbrot(current_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing, false);
                 cpu_results = current_results;
@@ -121,8 +123,8 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
+                    //throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
@@ -138,8 +140,10 @@ void run(int argc, char** argv)
                        float sizeX; float sizeY;
                         uint iters; uint isSmoothing;
                     } params = { width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing };
-                    // TODO vk_mandelbrot.exec(params, ...);
+                    
+                    // TODO vk_mandelbrot.exec(params...);
                     throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+
                 } else {
                     rassert(false, 546345243, context.type());
                 }


### PR DESCRIPTION
<details>
<summary>Локальный вывод</summary>
<pre>
Found 3 GPUs in 0.353468 sec (OpenCL: 0.147489 sec, Vulkan: 0.205294 sec)
Available devices:
  Device #0: API: OpenCL. GPU. AMD Radeon(TM) RX Vega 10 Graphics (gfx902). Free memory: 7138/7206 Mb.
  Device #1: API: OpenCL. CPU. AMD Ryzen 7 3750H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 14269 Mb.
  Device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce GTX 1650. Free memory: 3344/4095 Mb.
Using device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce GTX 1650. Free memory: 3344/4095 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=4.24607 10%=4.24607 median=4.24607 90%=4.24607 max=4.24607)
Mandelbrot effective algorithm GFlops: 2.35512 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x8 threads
algorithm times (in seconds) - 10 values (min=0.763702 10%=0.813386 median=1.04878 90%=1.16206 max=1.16206)
Mandelbrot effective algorithm GFlops: 9.53486 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.697804 seconds
algorithm times (in seconds) - 10 values (min=0.0044371 10%=0.0044395 median=0.004499 90%=0.741996 max=0.741996)
Mandelbrot effective algorithm GFlops: 2222.72 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%


Found 3 GPUs in 0.353974 sec (OpenCL: 0.148671 sec, Vulkan: 0.204663 sec)
Available devices:
  Device #0: API: OpenCL. GPU. AMD Radeon(TM) RX Vega 10 Graphics (gfx902). Free memory: 7138/7206 Mb.
  Device #1: API: OpenCL. CPU. AMD Ryzen 7 3750H with Radeon Vega Mobile Gfx  . Intel(R) Corporation. Total memory: 14269 Mb.
  Device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce GTX 1650. Free memory: 3344/4095 Mb.
Using device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce GTX 1650. Free memory: 3344/4095 Mb.
Using Vulkan API...
Debug printf was requested, but validation layers were disabled so debug printf will not work, please enable validation layers with context.setVKValidationLayers(true) after calling context.initVulkan(...)
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.227315 10%=0.229987 median=0.23651 90%=0.27295 max=0.27295)
sum median effective algorithm bandwidth: 1.57511 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.042906 10%=0.0459972 median=0.0528647 90%=0.0581464 max=0.0581464)
sum median effective algorithm bandwidth: 7.04684 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
algorithm times (in seconds) - 10 values (min=0.0055867 10%=0.0056723 median=0.0058527 90%=0.0099741 max=0.0099741)
sum median effective algorithm bandwidth: 63.6508 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
algorithm times (in seconds) - 10 values (min=0.0039242 10%=0.0039464 median=0.0040688 90%=0.0054023 max=0.0054023)
sum median effective algorithm bandwidth: 91.5575 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
.0053533 90%=0.0067093 max=0.0067093)
sum median effective algorithm bandwidth: 69.5887 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
algorithm times (in seconds) - 10 values (min=0.0066925 10%=0.006709 median=0.0069235 90%=0.0082928 max=0.0082928)
sum median effective algorithm bandwidth: 53.8065 GB/s
</pre>
</details>

<details>
<summary>Github CI вывод</summary>
<pre>
Run ./main_mandelbrot 0
Found 2 GPUs in 0.0445889 sec (CUDA: 8.503e-05 sec, OpenCL: 0.0199834 sec, Vulkan: 0.0244727 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00298 10%=2.00298 median=2.00298 90%=2.00298 max=2.00298)
Mandelbrot effective algorithm GFlops: 4.99256 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.606862 10%=0.606984 median=0.610696 90%=0.721686 max=0.721686)
Mandelbrot effective algorithm GFlops: 16.3747 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.173673 seconds
algorithm times (in seconds) - 10 values (min=0.152278 10%=0.15228 median=0.152346 90%=0.328347 max=0.328347)
Mandelbrot effective algorithm GFlops: 65.6403 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%


Run ./main_sum 0
Found 2 GPUs in 0.0455185 sec (CUDA: 8.1233e-05 sec, OpenCL: 0.0202126 sec, Vulkan: 0.0251802 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Device AMD EPYC 7763 64-Core Processor                 doesn't support Vulkan
Error: Device doesn't support requested API
</pre>
</details>