### PR TITLE
Task02 Дмитрий Хорошенко HSE

### DIFF
--- a/src/kernels/cu/mandelbrot.cu
+++ b/src/kernels/cu/mandelbrot.cu
@@ -16,7 +16,28 @@ __global__ void mandelbrot(float* results,
     const unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // TODO
+    const float THRESHOLD = 256.0f;
+    const float THRESHOLD_SQUARE = THRESHOLD * THRESHOLD;
+    if (i >= width || j >= height) return;
+    const float x_begin = fromX + (i + 0.5f) * sizeX / width;
+    const float y_begin = fromY + (j + 0.5f) * sizeY / height;
+    unsigned int iter = 0;
+    float current_x = x_begin;
+    float current_y = y_begin;
+    for (; iter < iters; ++iter) {
+        float previous_x = current_x;
+        current_x = current_x * current_x - current_y * current_y + x_begin;
+        current_y = 2.0f * previous_x * current_y + y_begin;
+        if ((current_x * current_x + current_y * current_y) > THRESHOLD_SQUARE) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result -= log(log(sqrt(current_x * current_x + current_y * current_y)) / (log(THRESHOLD) * log(2.0f)));
+    }
+    result *= 1.0f/iters;
+    results[i + j * width] = result;
 }
 
 namespace cuda {

--- a/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
+++ b/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
@@ -18,6 +18,19 @@ __global__ void sum_03_local_memory_atomic_per_workgroup(
     // __syncthreads();
 
     // TODO
+    const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int local_index = threadIdx.x;
+    __shared__ unsigned local_data[GROUP_SIZE];
+    local_data[local_index] = (index >= n) ? 0 : a[index];
+    __syncthreads();
+    if (local_index == 0) {
+        unsigned int local_sum = 0;
+        for (unsigned int i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        atomicAdd(sum, local_sum);
+    }
+
 }
 
 namespace cuda {

--- a/src/kernels/cu/sum_04_local_reduction.cu
+++ b/src/kernels/cu/sum_04_local_reduction.cu
@@ -14,11 +14,18 @@ __global__ void sum_04_local_reduction(
     unsigned int  n)
 {
     // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
-
+    const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int local_index = threadIdx.x;
+    __shared__ unsigned local_data[GROUP_SIZE];
+    local_data[local_index] = (index >= n) ? 0 : a[index];
+    __syncthreads();
+    if (local_index==0) {
+        unsigned int local_sum = 0;
+        for (unsigned int i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        b[blockIdx.x] = local_sum;
+    }
     // TODO
 }
 

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -58,7 +58,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -126,8 +126,7 @@ void run(int argc, char** argv)
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
-                    // TODO cuda::mandelbrot(..);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    cuda::mandelbrot(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height), gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
 
                     // _______________________________Vulkan_________________________________________
                 } else if (context.type() == gpu::Context::TypeVulkan) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -37,7 +37,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -72,10 +72,15 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u reduction_buffer2_gpu(div_ceil(n, (unsigned int)GROUP_SIZE));
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    input_gpu.writeN(values.data(), n);
-    // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
-    // TODO 2) сделайте замер хотя бы три раза
-    // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+
+    std::vector<double> times;
+    for (int iter = 0; iter < 3; ++iter) {
+        timer t;
+        input_gpu.writeN(values.data(), n);
+        times.push_back(t.elapsed());
+    }
+    double memory_size_gb = sizeof(unsigned int) * n / 1024.0 / 1024.0 / 1024.0;
+    std::cout << "PCI-E bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -92,7 +97,6 @@ void run(int argc, char** argv)
         std::cout << "Evaluating algorithm #" << (algorithm_index + 1) << "/" << algorithm_names.size() << ": " << algorithm << std::endl;
 
         // Запускаем алгоритм (несколько раз и с замером времени выполнения)
-        std::vector<double> times;
         unsigned int gpu_sum = 0;
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
@@ -132,11 +136,23 @@ void run(int argc, char** argv)
                         cuda::sum_02_atomics_load_k(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO cuda::sum_03_local_memory_atomic_per_workgroup(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        cuda::sum_03_local_memory_atomic_per_workgroup(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO cuda::sum_04_local_reduction(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        unsigned int buffer_size = n;
+                        bool is_first_in = true;
+                        cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, buffer_size), input_gpu, reduction_buffer1_gpu, buffer_size);
+                        buffer_size = (buffer_size / GROUP_SIZE) + (buffer_size % GROUP_SIZE != 0);
+                        for (; buffer_size > 1; buffer_size = (buffer_size / GROUP_SIZE) + (buffer_size % GROUP_SIZE != 0)) {
+                            gpu::gpu_mem_32u& input_buffer = is_first_in ? reduction_buffer1_gpu : reduction_buffer2_gpu;
+                            gpu::gpu_mem_32u& output_buffer = is_first_in ? reduction_buffer2_gpu : reduction_buffer1_gpu;
+                            cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, buffer_size), input_buffer, output_buffer, buffer_size);
+                            is_first_in ^= true;
+                        }
+                        gpu::gpu_mem_32u& answer = is_first_in ? reduction_buffer1_gpu : reduction_buffer2_gpu;
+                        answer.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 3 GPUs in 0.215904 sec (CUDA: 0.0245358 sec, OpenCL: 0.114363 sec, Vulkan: 0.0765265 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13620H. Intel(R) Corporation. Total memory: 16087 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) UHD Graphics. Free memory: 7385/7111 Mb.
  Device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 4060 Laptop GPU (CUDA 12080). Free memory: 7099/8187 Mb.
Using device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 4060 Laptop GPU (CUDA 12080). Free memory: 7099/8187 Mb.
Using CUDA API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.57905 10%=2.57905 median=2.57905 90%=2.57905 max=2.57905)
Mandelbrot effective algorithm GFlops: 3.8774 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x16 threads
algorithm times (in seconds) - 10 values (min=0.304807 10%=0.310356 median=0.3265 90%=0.355306 max=0.355306)
Mandelbrot effective algorithm GFlops: 30.6278 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
algorithm times (in seconds) - 10 values (min=0.0100209 10%=0.0100273 median=0.0110343 90%=0.0115924 max=0.0115924)
Mandelbrot effective algorithm GFlops: 906.265 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum 2
Found 3 GPUs in 1.82129 sec (CUDA: 1.63681 sec, OpenCL: 0.10569 sec, Vulkan: 0.0783183 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 13th Gen Intel(R) Core(TM) i7-13620H. Intel(R) Corporation. Total memory: 16087 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) UHD Graphics. Free memory: 7385/7111 Mb.
  Device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 4060 Laptop GPU (CUDA 12080). Free memory: 7099/8187 Mb.
Using device #2: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 4060 Laptop GPU (CUDA 12080). Free memory: 7099/8187 Mb.
Using CUDA API...
PCI-E bandwidth: 6.58085 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 13 values (min=0.0525605 10%=0.0542645 median=0.0559688 90%=0.0590217 max=0.0603482)
sum median effective algorithm bandwidth: 6.65601 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 23 values (min=0.0106143 10%=0.0108828 median=0.0542645 90%=0.0582261 max=0.0603482)
sum median effective algorithm bandwidth: 6.86506 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
algorithm times (in seconds) - 33 values (min=0.0019267 10%=0.0019709 median=0.0120473 90%=0.0569026 max=0.0603482)
sum median effective algorithm bandwidth: 30.9222 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
algorithm times (in seconds) - 43 values (min=0.001918 10%=0.0019578 median=0.0108622 90%=0.056608 max=0.0603482)
sum median effective algorithm bandwidth: 34.2959 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
algorithm times (in seconds) - 53 values (min=0.001918 10%=0.0019604 median=0.0022824 90%=0.0560016 max=0.0603482)
sum median effective algorithm bandwidth: 163.218 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
algorithm times (in seconds) - 63 values (min=0.001918 10%=0.001964 median=0.002515 90%=0.0559688 max=0.0603482)
sum median effective algorithm bandwidth: 148.123 GB/s
</pre>

</p></details>