### PR TITLE
Task02 Федор Ромашов HSE

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,29 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    uint iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -9,11 +9,25 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        __global       uint* sum,
                                                        const unsigned int n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint i = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (i < n) {
+        local_data[local_index] = a[i];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint local_sum = 0;
+        for (uint j = 0; j < GROUP_SIZE; ++j) {
+            local_sum += local_data[j];
+        }
+        atomic_add(sum, local_sum);
+    }
+
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -11,11 +11,24 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                      __global       uint* b,
                                             unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint i = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (i < n) {
+        local_data[local_index] = a[i];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint local_sum = 0;
+        for (uint j = 0; j < GROUP_SIZE; ++j) {
+            local_sum += local_data[j];
+        }
+        b[get_group_id(0)] = local_sum;
+    }
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,8 +121,15 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    ocl_mandelbrot.exec(
+                        workSize,
+                        gpu_results, 
+                        width, height, 
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, 
+                        sizeX, sizeY, 
+                        iterationsLimit, isSmoothing
+                    );
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -73,9 +73,18 @@ void run(int argc, char** argv)
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
     input_gpu.writeN(values.data(), n);
-    // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
-    // TODO 2) сделайте замер хотя бы три раза
-    // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+
+    {
+        std::vector<double> times;
+        for(size_t iter = 0; iter < 3; ++iter) {
+            timer t;
+            input_gpu.writeN(values.data(), n);
+            times.push_back(t.elapsed());
+        }
+        std::cout << "PCI-E upload times (in seconds) - " << stats::valuesStatsLine(times) << std::endl;
+        double memory_size_gb = sizeof(unsigned int) * n / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "PCI-E bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
+    }
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -113,11 +122,20 @@ void run(int argc, char** argv)
                         ocl_sum02AtomicsLoadK.exec(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO ocl_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, reduction_buffer1_gpu, n);
+                        uint current_n = div_ceil(n, (unsigned int)GROUP_SIZE);
+                        while (current_n > 1) {
+                            uint next_n = div_ceil(current_n, (unsigned int)GROUP_SIZE);
+                            ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, current_n), reduction_buffer1_gpu, reduction_buffer2_gpu, current_n);
+                            current_n = next_n;
+                            std::swap(reduction_buffer1_gpu, reduction_buffer2_gpu);
+                        }
+                        reduction_buffer1_gpu.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
macbook@MacBook-Fedor build % ./main_mandelbrot 
Found 1 GPUs in 0.0882073 sec (OpenCL: 0.069108 sec, Vulkan: 0.0190709 sec)
Available devices:
  Device #0: API: OpenCL+Vulkan. GPU. Apple M1 Pro. Free memory: 10922/10922 Mb.
Using device #0: API: OpenCL+Vulkan. GPU. Apple M1 Pro. Free memory: 10922/10922 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=4.02605 10%=4.02605 median=4.02605 90%=4.02605 max=4.02605)
Mandelbrot effective algorithm GFlops: 2.48382 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x1 threads
algorithm times (in seconds) - 10 values (min=3.99764 10%=4.00523 median=4.04393 90%=4.07589 max=4.07589)
Mandelbrot effective algorithm GFlops: 2.47284 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.00147325 seconds
algorithm times (in seconds) - 10 values (min=0.00495471 10%=0.00496321 median=0.00499108 90%=0.0128868 max=0.0128868)
Mandelbrot effective algorithm GFlops: 2003.57 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0%

macbook@MacBook-Fedor build % ./main_sum
Found 1 GPUs in 0.0780262 sec (OpenCL: 0.0679794 sec, Vulkan: 0.0100174 sec)
Available devices:
  Device #0: API: OpenCL+Vulkan. GPU. Apple M1 Pro. Free memory: 10922/10922 Mb.
Using device #0: API: OpenCL+Vulkan. GPU. Apple M1 Pro. Free memory: 10922/10922 Mb.
Using OpenCL API...
PCI-E upload times (in seconds) - 3 values (min=0.0149623 10%=0.0149623 median=0.0154783 90%=0.0166178 max=0.0166178)
PCI-E bandwidth: 24.0679 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0931406 10%=0.0931741 median=0.093335 90%=0.0947576 max=0.0947576)
sum median effective algorithm bandwidth: 3.99131 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0937567 10%=0.0945663 median=0.0955805 90%=0.0995749 max=0.0995749)
sum median effective algorithm bandwidth: 3.89754 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.00183425 seconds
algorithm times (in seconds) - 10 values (min=0.00547383 10%=0.00547512 median=0.00563613 90%=0.0148133 max=0.0148133)
sum median effective algorithm bandwidth: 66.0967 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.000248875 seconds
algorithm times (in seconds) - 10 values (min=0.0034905 10%=0.003491 median=0.00368442 90%=0.00604088 max=0.00604088)
sum median effective algorithm bandwidth: 101.109 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.00122042 seconds
algorithm times (in seconds) - 10 values (min=0.00643413 10%=0.00644004 median=0.00649354 90%=0.018234 max=0.018234)
sum median effective algorithm bandwidth: 57.3692 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.00027475 seconds
algorithm times (in seconds) - 10 values (min=0.00712538 10%=0.00713367 median=0.00720054 90%=0.0188383 max=0.0188383)
sum median effective algorithm bandwidth: 51.7363 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
</pre>

</p></details>