### PR TITLE
Task02 Егор Федосеев ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -12,8 +12,31 @@ __kernel void mandelbrot(__global float* results,
                      float sizeX, float sizeY,
                      unsigned int iters, unsigned int isSmoothing)
 {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -16,4 +16,23 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
     // barrier(CLK_LOCAL_MEM_FENCE);
 
     // TODO
+
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
+    
+    local_data[local_index] = (index < n ? a[index] : 0);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (index >= n) {
+        return;
+    }
+
+    if (local_index == 0) {
+        uint localSum = 0;
+        for (uint i = 0; i < GROUP_SIZE; ++i) {
+            localSum += local_data[i];
+        }
+        atomic_add(sum, localSum);
+    }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -18,4 +18,32 @@ __kernel void sum_04_local_reduction(__global const uint* a,
     // barrier(CLK_LOCAL_MEM_FENCE);
 
     // TODO
+
+    const uint index = get_global_id(0);
+    
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
+    const uint warpsCnt = GROUP_SIZE / WARP_SIZE;
+    __local uint localReduction[warpsCnt];
+
+    local_data[local_index] = (index < n ? a[index] : 0);
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index % WARP_SIZE == 0) {
+        uint localSum = 0;
+        for (uint i = 0; i < WARP_SIZE; ++i) {
+            localSum += local_data[local_index + i];
+        }
+        // printf("warp idx: %d   sum: %d\n", index, localSum);
+        localReduction[local_index / WARP_SIZE] = localSum;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (local_index == 0) {
+        uint localSum = 0;
+        for (uint i = 0; i < warpsCnt; ++i) {
+            localSum += localReduction[i];
+        }
+        // printf("group idx: %d   sum: %d\n", index, localSum);
+        b[index / GROUP_SIZE] = localSum;    
+    }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 4 GPUs in 0.0859047 sec (OpenCL: 0.0699633 sec, Vulkan: 0.0158851 sec)
Available devices:
  Device #0: API: Vulkan. iGPU. AMD Radeon Graphics (RADV RENOIR). Free memory: 6309/7299 Mb.
  Device #1: API: OpenCL. GPU. AMD Radeon Graphics (radeonsi, renoir, ACO, DRM 3.57, 6.8.0-85-generic). Total memory: 8901 Mb.
  Device #2: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 17803 Mb.
  Device #3: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 17803/17803 Mb.
Using device #2: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 17803 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=3.44772 10%=3.44772 median=3.44772 90%=3.44772 max=3.44772)
Mandelbrot effective algorithm GFlops: 2.90047 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x12 threads
algorithm times (in seconds) - 10 values (min=0.379543 10%=0.379984 median=0.385523 90%=0.417439 max=0.417439)
Mandelbrot effective algorithm GFlops: 25.9388 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.143597 seconds
algorithm times (in seconds) - 10 values (min=0.0522602 10%=0.0523434 median=0.0529127 90%=0.196276 max=0.196276)
Mandelbrot effective algorithm GFlops: 188.991 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 4 GPUs in 0.0864896 sec (OpenCL: 0.0696777 sec, Vulkan: 0.0167564 sec)
Available devices:
  Device #0: API: Vulkan. iGPU. AMD Radeon Graphics (RADV RENOIR). Free memory: 6285/7299 Mb.
  Device #1: API: OpenCL. GPU. AMD Radeon Graphics (radeonsi, renoir, ACO, DRM 3.57, 6.8.0-85-generic). Total memory: 8901 Mb.
  Device #2: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 17803 Mb.
  Device #3: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 17803/17803 Mb.
Using device #2: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 17803 Mb.
Using OpenCL API...
PCI-E bus bandwidth: 6.58662 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.175717 10%=0.178518 median=0.182726 90%=0.187707 max=0.187707)
sum median effective algorithm bandwidth: 2.03873 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0226004 10%=0.0280169 median=0.0306151 90%=0.0440116 max=0.0440116)
sum median effective algorithm bandwidth: 12.1681 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.121141 seconds
algorithm times (in seconds) - 10 values (min=0.800729 10%=0.801312 median=0.80343 90%=0.927181 max=0.927181)
sum median effective algorithm bandwidth: 0.463673 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0318007 seconds
algorithm times (in seconds) - 10 values (min=0.404678 10%=0.404861 median=0.405521 90%=0.441466 max=0.441466)
sum median effective algorithm bandwidth: 0.918643 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0410378 seconds
algorithm times (in seconds) - 10 values (min=0.0246563 10%=0.0251235 median=0.0260105 90%=0.0688362 max=0.0688362)
sum median effective algorithm bandwidth: 14.3223 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0428397 seconds
algorithm times (in seconds) - 10 values (min=0.0224357 10%=0.0237347 median=0.0247264 90%=0.0670889 max=0.0670889)
sum median effective algorithm bandwidth: 15.066 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot
Found 2 GPUs in 0.0459806 sec (CUDA: 8.039e-05 sec, OpenCL: 0.0205936 sec, Vulkan: 0.0252616 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00175 10%=2.00175 median=2.00175 90%=2.00175 max=2.00175)
Mandelbrot effective algorithm GFlops: 4.99563 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.60727 10%=0.607388 median=0.60781 90%=0.649432 max=0.649432)
Mandelbrot effective algorithm GFlops: 16.4525 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.152253 seconds
algorithm times (in seconds) - 10 values (min=0.159467 10%=0.160073 median=0.164424 90%=0.314242 max=0.314242)
Mandelbrot effective algorithm GFlops: 60.8183 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 2 GPUs in 0.0456666 sec (CUDA: 8.0942e-05 sec, OpenCL: 0.0205971 sec, Vulkan: 0.0249453 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCI-E bus bandwidth: 15.5105 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0328003 10%=0.0328306 median=0.0329553 90%=0.0345779 max=0.0345779)
sum median effective algorithm bandwidth: 11.3041 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0211536 10%=0.0212515 median=0.0213242 90%=0.0219565 max=0.0219565)
sum median effective algorithm bandwidth: 17.4698 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.111596 seconds
algorithm times (in seconds) - 10 values (min=1.42511 10%=1.42592 median=1.43361 90%=1.53844 max=1.53844)
sum median effective algorithm bandwidth: 0.259853 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0295141 seconds
algorithm times (in seconds) - 10 values (min=0.710523 10%=0.71777 median=0.718189 90%=0.748153 max=0.748153)
sum median effective algorithm bandwidth: 0.518706 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0465719 seconds
algorithm times (in seconds) - 10 values (min=0.0589402 10%=0.0590695 median=0.0591555 90%=0.106502 max=0.106502)
sum median effective algorithm bandwidth: 6.29746 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0393773 seconds
algorithm times (in seconds) - 10 values (min=0.0782429 10%=0.0782618 median=0.0785535 90%=0.118818 max=0.118818)
sum median effective algorithm bandwidth: 4.74236 GB/s
</pre>

</p></details>