### PR TITLE
 Task02 Aldar Antonov HSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(GPGPUTasks)
 set(CMAKE_CXX_STANDARD 17)
 
 # Если вы установили CUDA SDK - можете включить поддержку CUDA
-option(GPU_CUDA_SUPPORT "CUDA support." OFF)
+option(GPU_CUDA_SUPPORT "CUDA support." ON)
 
 # GLSLC_BIN используйтся для компиляции Vulkan шейдеров (GLSL)
 if (NOT DEFINED GLSLC_BIN)

--- a/src/kernels/cu/mandelbrot.cu
+++ b/src/kernels/cu/mandelbrot.cu
@@ -1,27 +1,53 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
-#include "helpers/rassert.cu"
 #include "../defines.h"
+#include "helpers/rassert.cu"
 
 __global__ void mandelbrot(float* results,
-                        unsigned int width, unsigned int height,
-                        float fromX, float fromY,
-                        float sizeX, float sizeY,
-                        unsigned int iters, unsigned int isSmoothing)
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, unsigned int isSmoothing)
 {
     const unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    if (j < height && i < width) {
+        float x0 = fromX + (i + 0.5f) * sizeX / width;
+        float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+        float x = x0;
+        float y = y0;
+
+        int iter = 0;
+        for (; iter < iters; ++iter) {
+            float xPrev = x;
+            x = x * x - y * y + x0;
+            y = 2.0f * xPrev * y + y0;
+            if ((x * x + y * y) > threshold2) {
+                break;
+            }
+        }
+        float result = iter;
+        if (isSmoothing && iter != iters) {
+            result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
+        }
+
+        result = 1.0f * result / iters;
+        results[j * width + i] = result;
+    }
 }
 
 namespace cuda {
-void mandelbrot(const gpu::WorkSize &workSize,
-    const gpu::gpu_mem_32f &results,
+void mandelbrot(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32f& results,
     unsigned int width, unsigned int height,
     float fromX, float fromY,
     float sizeX, float sizeY,

--- a/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
+++ b/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
@@ -1,6 +1,6 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
@@ -9,20 +9,30 @@
 __global__ void sum_03_local_memory_atomic_per_workgroup(
     const unsigned int* a,
     unsigned int* sum,
-    unsigned int  n)
+    unsigned int n)
 {
-    // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
-
-    // TODO
+    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
+    if (index < n) {
+        local_data[local_index] = 0;
+        local_data[local_index] += a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    __syncthreads();
+    if (local_index == 0) {
+        unsigned int local_sum = 0;
+        for (int i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        atomicAdd(sum, local_sum);
+    }
 }
 
 namespace cuda {
-void sum_03_local_memory_atomic_per_workgroup(const gpu::WorkSize &workSize,
-    const gpu::gpu_mem_32u &a, gpu::gpu_mem_32u &sum, unsigned int n)
+void sum_03_local_memory_atomic_per_workgroup(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32u& a, gpu::gpu_mem_32u& sum, unsigned int n)
 {
     gpu::Context context;
     rassert(context.type() == gpu::Context::TypeCUDA, 6573652345243, context.type());

--- a/src/kernels/cu/sum_04_local_reduction.cu
+++ b/src/kernels/cu/sum_04_local_reduction.cu
@@ -1,6 +1,6 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
@@ -11,20 +11,30 @@
 __global__ void sum_04_local_reduction(
     const unsigned int* a,
     unsigned int* b,
-    unsigned int  n)
+    unsigned int n)
 {
-    // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
-
-    // TODO
+    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
+    if (index < n) {
+        local_data[local_index] = 0;
+        local_data[local_index] += a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    __syncthreads();
+    if (local_index == 0) {
+        unsigned int local_sum = 0;
+        for (int i = 0; i < GROUP_SIZE; ++i) {
+            local_sum += local_data[i];
+        }
+        b[index / GROUP_SIZE] = local_sum;
+    }
 }
 
 namespace cuda {
-void sum_04_local_reduction(const gpu::WorkSize &workSize,
-    const gpu::gpu_mem_32u &a, gpu::gpu_mem_32u &sum, unsigned int n)
+void sum_04_local_reduction(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32u& a, gpu::gpu_mem_32u& sum, unsigned int n)
 {
     gpu::Context context;
     rassert(context.type() == gpu::Context::TypeCUDA, 6573652345243, context.type());

--- a/src/main_aplusb.cpp
+++ b/src/main_aplusb.cpp
@@ -23,7 +23,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -96,7 +96,8 @@ int main(int argc, char** argv)
         if (e.what() == DEVICE_NOT_SUPPORT_API) {
             // Возвращаем exit code = 0 чтобы на CI не было красного крестика о неуспешном запуске из-за выбора CUDA API (его нет на процессоре - т.е. в случае CI на GitHub Actions)
             return 0;
-        } if (e.what() == CODE_IS_NOT_IMPLEMENTED) {
+        }
+        if (e.what() == CODE_IS_NOT_IMPLEMENTED) {
             // Возвращаем exit code = 0 чтобы на CI не было красного крестика о неуспешном запуске из-за того что задание еще не выполнено
             return 0;
         } else {

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -1,9 +1,9 @@
+#include <libbase/omp_utils.h>
 #include <libbase/stats.h>
 #include <libbase/timer.h>
-#include <libutils/misc.h>
-#include <libimages/images.h>
-#include <libbase/omp_utils.h>
 #include <libgpu/vulkan/engine.h>
+#include <libimages/images.h>
+#include <libutils/misc.h>
 
 #include "kernels/defines.h"
 #include "kernels/kernels.h"
@@ -11,16 +11,16 @@
 #include <fstream>
 
 void cpu::mandelbrot(float* results,
-                   unsigned int width, unsigned int height,
-                   float fromX, float fromY,
-                   float sizeX, float sizeY,
-                   unsigned int iters, unsigned int isSmoothing,
-                   bool useOpenMP)
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, unsigned int isSmoothing,
+    bool useOpenMP)
 {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
 
-    #pragma omp parallel for if(useOpenMP)
+#pragma omp parallel for if (useOpenMP)
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -58,7 +58,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -100,6 +100,9 @@ void run(int argc, char** argv)
         "GPU",
     };
 
+    // Настраиваем размер рабочего пространства 2d = workSizeX == workSizeY == width == height, groupSizeX == groupSizeY == 1024
+    gpu::WorkSize workSize(32, 32, width, height);
+
     for (size_t algorithm_index = 0; algorithm_index < algorithm_names.size(); ++algorithm_index) {
         const std::string& algorithm = algorithm_names[algorithm_index];
         std::cout << "______________________________________________________" << std::endl;
@@ -116,7 +119,8 @@ void run(int argc, char** argv)
                 cpu::mandelbrot(current_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing, false);
                 cpu_results = current_results;
             } else if (algorithm == "CPU with OpenMP") {
-                if (iter == 0) std::cout << "OpenMP threads: x" << getOpenMPThreadsCount() << " threads" << std::endl;
+                if (iter == 0)
+                    std::cout << "OpenMP threads: x" << getOpenMPThreadsCount() << " threads" << std::endl;
                 cpu::mandelbrot(current_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing, true);
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
@@ -126,17 +130,19 @@ void run(int argc, char** argv)
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
-                    // TODO cuda::mandelbrot(..);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
+                    cuda::mandelbrot(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
                     // _______________________________Vulkan_________________________________________
                 } else if (context.type() == gpu::Context::TypeVulkan) {
                     typedef unsigned int uint;
                     struct {
-                        uint width; uint height;
-                       float fromX; float fromY;
-                       float sizeX; float sizeY;
-                        uint iters; uint isSmoothing;
+                        uint width;
+                        uint height;
+                        float fromX;
+                        float fromY;
+                        float sizeX;
+                        float sizeY;
+                        uint iters;
+                        uint isSmoothing;
                     } params = { width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing };
                     // TODO vk_mandelbrot.exec(params, ...);
                     throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
@@ -156,7 +162,7 @@ void run(int argc, char** argv)
         // Вычисляем достигнутую эффективную пропускную способность алгоритма (из соображений что мы все итерации делались полностью, без быстрого выхода через break)
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "Mandelbrot effective algorithm GFlops: " << maxApproximateFlops / gflops / stats::median(times) << " GFlops" << std::endl;
 
         // Сохраняем картинку
@@ -209,40 +215,53 @@ int main(int argc, char** argv)
 }
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+    vec3f(float x, float y, float z)
+        : x(x)
+        , y(y)
+        , z(z)
+    {
+    }
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
-vec3f operator+(const vec3f &a, const vec3f &b) {
-    return {a.x + b.x, a.y + b.y, a.z + b.z};
+vec3f operator+(const vec3f& a, const vec3f& b)
+{
+    return { a.x + b.x, a.y + b.y, a.z + b.z };
 }
 
-vec3f operator*(const vec3f &a, const vec3f &b) {
-    return {a.x * b.x, a.y * b.y, a.z * b.z};
+vec3f operator*(const vec3f& a, const vec3f& b)
+{
+    return { a.x * b.x, a.y * b.y, a.z * b.z };
 }
 
-vec3f operator*(const vec3f &a, float t) {
-    return {a.x * t, a.y * t, a.z * t};
+vec3f operator*(const vec3f& a, float t)
+{
+    return { a.x * t, a.y * t, a.z * t };
 }
 
-vec3f operator*(float t, const vec3f &a) {
+vec3f operator*(float t, const vec3f& a)
+{
     return a * t;
 }
 
-vec3f sin(const vec3f &a) {
-    return {sinf(a.x), sinf(a.y), sinf(a.z)};
+vec3f sin(const vec3f& a)
+{
+    return { sinf(a.x), sinf(a.y), sinf(a.z) };
 }
 
-vec3f cos(const vec3f &a) {
-    return {cosf(a.x), cosf(a.y), cosf(a.z)};
+vec3f cos(const vec3f& a)
+{
+    return { cosf(a.x), cosf(a.y), cosf(a.z) };
 }
 
 image8u renderToColor(const float* results, unsigned int width, unsigned int height)
 {
     image8u image(width, height, 3);
-    unsigned char *img_rgb = image.ptr();
-    #pragma omp parallel for
+    unsigned char* img_rgb = image.ptr();
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -251,10 +270,10 @@ image8u renderToColor(const float* results, unsigned int width, unsigned int hei
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
-            img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
-            img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
-            img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
+            img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char)(color.x * 255);
+            img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char)(color.y * 255);
+            img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char)(color.z * 255);
         }
     }
     return image;

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -23,7 +23,7 @@ unsigned int cpu::sum(const unsigned int* values, unsigned int n)
 unsigned int cpu::sumOpenMP(const unsigned int* values, unsigned int n)
 {
     unsigned int sum = 0;
-    #pragma omp parallel for schedule(dynamic, 1024) reduction(+ : sum)
+#pragma omp parallel for schedule(dynamic, 1024) reduction(+ : sum)
     for (ptrdiff_t i = 0; i < n; ++i) {
         sum += values[i];
     }
@@ -37,7 +37,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -76,7 +76,14 @@ void run(int argc, char** argv)
     // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
     // TODO 2) сделайте замер хотя бы три раза
     // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
-
+    std::vector<double> times;
+    for (int i = 0; i < 9; i++) {
+        timer t;
+        input_gpu.writeN(values.data(), n);
+        times.push_back(t.elapsed());
+    }
+    double size_of_the_data_in_gb = (double)n * sizeof(unsigned int) / 1024.0 / 1024.0 / 1024.0;
+    std::cout << "PCI-E median bandwidth: " << size_of_the_data_in_gb / stats::median(times) << " GB/s" << std::endl;
     std::vector<std::string> algorithm_names = {
         "CPU",
         "CPU with OpenMP",
@@ -132,11 +139,18 @@ void run(int argc, char** argv)
                         cuda::sum_02_atomics_load_k(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO cuda::sum_03_local_memory_atomic_per_workgroup(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        cuda::sum_03_local_memory_atomic_per_workgroup(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO cuda::sum_04_local_reduction(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        auto& destination = reduction_buffer1_gpu;
+                        auto& source = reduction_buffer2_gpu;
+                        cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, n), input_gpu, destination, n);
+                        for (auto next_size = (n + GROUP_SIZE - 1) / GROUP_SIZE; next_size > 1; next_size = (next_size + GROUP_SIZE - 1) / GROUP_SIZE) {
+                            std::swap(source, destination);
+                            cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, next_size), source, destination, next_size);
+                        }
+                        destination.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
./build/main_mandelbrot 1
Found 8 GPUs in 1.05391 sec (CUDA: 0.218255 sec, OpenCL: 0.182653 sec, Vulkan: 0.652735 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 11659/16004 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 15837/16004 Mb.
  Device #2: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7688/7789 Mb.
  Device #3: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7459/7789 Mb.
  Device #4: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7691/7789 Mb.
  Device #5: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7691/7789 Mb.
  Device #6: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7691/7789 Mb.
  Device #7: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 515838/515838 Mb.
Using device #1: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 15837/16004 Mb.
Using CUDA API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=3.46993 10%=3.46993 median=3.46993 90%=3.46993 max=3.46993)
Mandelbrot effective algorithm GFlops: 2.8819 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x72 threads
algorithm times (in seconds) - 10 values (min=0.0998986 10%=0.102494 median=0.109973 90%=0.125116 max=0.125116)
Mandelbrot effective algorithm GFlops: 90.9318 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
algorithm times (in seconds) - 10 values (min=0.00129226 10%=0.00129235 median=0.00129572 90%=0.00184265 max=0.00184265)
Mandelbrot effective algorithm GFlops: 7717.7 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%
Segmentation fault (core dumped)

./build/main_sum 1
Found 8 GPUs in 1.03547 sec (CUDA: 0.201189 sec, OpenCL: 0.155153 sec, Vulkan: 0.678773 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 11659/16004 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 15837/16004 Mb.
  Device #2: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7688/7789 Mb.
  Device #3: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7459/7789 Mb.
  Device #4: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 6663/7789 Mb.
  Device #5: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7691/7789 Mb.
  Device #6: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12060). Free memory: 7691/7789 Mb.
  Device #7: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 515838/515838 Mb.
Using device #1: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA RTX A4000 (CUDA 12060). Free memory: 15837/16004 Mb.
Using CUDA API...
PCI-E median bandwidth: 7.59486 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.248352 10%=0.24847 median=0.250557 90%=0.307806 max=0.307806)
sum median effective algorithm bandwidth: 1.48681 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0131613 10%=0.0132115 median=0.013418 90%=0.0178823 max=0.0178823)
sum median effective algorithm bandwidth: 27.7634 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
algorithm times (in seconds) - 10 values (min=0.00228631 10%=0.00228646 median=0.00228716 90%=0.00278549 max=0.00278549)
sum median effective algorithm bandwidth: 162.878 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
algorithm times (in seconds) - 10 values (min=0.00122163 10%=0.00122232 median=0.0012234 90%=0.00157385 max=0.00157385)
sum median effective algorithm bandwidth: 304.503 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
algorithm times (in seconds) - 10 values (min=0.00123141 10%=0.00123153 median=0.00123323 90%=0.00175739 max=0.00175739)
sum median effective algorithm bandwidth: 302.076 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
algorithm times (in seconds) - 10 values (min=0.0012548 10%=0.00125554 median=0.00125709 90%=0.00160467 max=0.00160467)
sum median effective algorithm bandwidth: 296.343 GB/s
Segmentation fault (core dumped)
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot 0
Found 2 GPUs in 0.0469667 sec (CUDA: 8.2895e-05 sec, OpenCL: 0.0211804 sec, Vulkan: 0.0256568 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Device AMD EPYC 7763 64-Core Processor                 doesn't support CUDA
Error: Device doesn't support requested API



./main_sum 0
Found 2 GPUs in 0.0499481 sec (CUDA: 8.9517e-05 sec, OpenCL: 0.0242629 sec, Vulkan: 0.0255438 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Device AMD EPYC 7763 64-Core Processor                 doesn't support CUDA
Error: Device doesn't support requested API


</pre>

</p></details>