### PR TITLE
Task02 Максим Федоров ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -12,8 +12,34 @@ __kernel void mandelbrot(__global float* results,
                      float sizeX, float sizeY,
                      unsigned int iters, unsigned int isSmoothing)
 {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    if (i >= width || j >= height) return;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0 * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -9,11 +9,21 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        __global       uint* sum,
                                                        const unsigned int n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+     const uint index = get_global_id(0);
+     const uint local_index = get_local_id(0);
+     __local uint local_data[GROUP_SIZE];
+     if (index < n) {
+         local_data[local_index] = a[index];
+     } else {
+         local_data[local_index] = 0;
+     }
+     barrier(CLK_LOCAL_MEM_FENCE);
 
-    // TODO
+     if (local_index == 0) {
+         uint my_sum = 0;
+         for (int i = 0; i < GROUP_SIZE; i++) {
+             my_sum += local_data[i];
+         }
+         atomic_add(sum, my_sum);
+     }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -11,11 +11,24 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                      __global       uint* b,
                                             unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint group_index = get_group_id(0);
+    const uint index = get_global_id(0);
+     const uint local_index = get_local_id(0);
+     __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (local_index == 0) {
+        uint my_sum = 0;
+        for (int i = 0; i < GROUP_SIZE; i++) {
+            my_sum += local_data[i];
+        }
+        b[group_index] = my_sum;
+    }
+
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -122,7 +122,9 @@ void run(int argc, char** argv)
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
                     // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
+//                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 3 GPUs in 0.0765697 sec (OpenCL: 0.0338367 sec, Vulkan: 0.0426539 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD Ryzen 7 5800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15389 Mb.
  Device #1: API: Vulkan. iGPU. AMD Unknown (RADV RENOIR). Free memory: 4518/5471 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15389/15389 Mb.
Using device #0: API: OpenCL. CPU. AMD Ryzen 7 5800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15389 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=3.32375 10%=3.32375 median=3.32375 90%=3.32375 max=3.32375)
Mandelbrot effective algorithm GFlops: 3.00865 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x16 threads
algorithm times (in seconds) - 10 values (min=0.384653 10%=0.384774 median=1.11305 90%=1.17319 max=1.17319)
Mandelbrot effective algorithm GFlops: 8.98435 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.197923 seconds
algorithm times (in seconds) - 10 values (min=0.0748907 10%=0.0751929 median=0.0756505 90%=0.28329 max=0.28329)
Mandelbrot effective algorithm GFlops: 132.187 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 3 GPUs in 0.0767886 sec (OpenCL: 0.0343362 sec, Vulkan: 0.0423756 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD Ryzen 7 5800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15389 Mb.
  Device #1: API: Vulkan. iGPU. AMD Unknown (RADV RENOIR). Free memory: 4496/5471 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 15.0.7, 256 bits). Free memory: 15389/15389 Mb.
Using device #0: API: OpenCL. CPU. AMD Ryzen 7 5800H with Radeon Graphics         . Intel(R) Corporation. Total memory: 15389 Mb.
Using OpenCL API...
PCIe write median bandwidth: 3.826 GB/s (median time 0.097 s over 5 runs)
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.098722 10%=0.10085 median=0.103016 90%=0.111224 max=0.111224)
sum median effective algorithm bandwidth: 3.616 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0184344 10%=0.0193317 median=0.02183 90%=0.0835569 max=0.0835569)
sum median effective algorithm bandwidth: 17.065 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.102 seconds
algorithm times (in seconds) - 10 values (min=1.17379 10%=1.17772 median=1.18301 90%=1.27124 max=1.27124)
sum median effective algorithm bandwidth: 0.315 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.026 seconds
algorithm times (in seconds) - 10 values (min=0.594174 10%=0.594277 median=0.595518 90%=0.617557 max=0.617557)
sum median effective algorithm bandwidth: 0.626 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.053 seconds
algorithm times (in seconds) - 10 values (min=0.0186904 10%=0.0268265 median=0.0311341 90%=0.119925 max=0.119925)
sum median effective algorithm bandwidth: 11.965 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.035 seconds
algorithm times (in seconds) - 10 values (min=0.0247856 10%=0.0253975 median=0.0287881 90%=0.122766 max=0.122766)
sum median effective algorithm bandwidth: 12.940 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot
Found 2 GPUs in 0.0479529 sec (CUDA: 8.8295e-05 sec, OpenCL: 0.0209463 sec, Vulkan: 0.0268669 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00051 10%=2.00051 median=2.00051 90%=2.00051 max=2.00051)
Mandelbrot effective algorithm GFlops: 4.99872 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.607026 10%=0.607104 median=0.607414 90%=0.633953 max=0.633953)
Mandelbrot effective algorithm GFlops: 16.4632 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.160921 seconds
algorithm times (in seconds) - 10 values (min=0.276208 10%=0.276295 median=0.305655 90%=0.439641 max=0.439641)
Mandelbrot effective algorithm GFlops: 32.7166 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 2 GPUs in 0.0532684 sec (CUDA: 8.1884e-05 sec, OpenCL: 0.0266908 sec, Vulkan: 0.0264453 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCIe write median bandwidth: 14.260 GB/s (median time 0.026 s over 5 runs)
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0324565 10%=0.0325139 median=0.0330733 90%=0.0370807 max=0.0370807)
sum median effective algorithm bandwidth: 11.264 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0214288 10%=0.0214699 median=0.0216538 90%=0.0229504 max=0.0229504)
sum median effective algorithm bandwidth: 17.204 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.111 seconds
algorithm times (in seconds) - 10 values (min=1.51639 10%=1.51923 median=1.52299 90%=1.63069 max=1.63069)
sum median effective algorithm bandwidth: 0.245 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.029 seconds
algorithm times (in seconds) - 10 values (min=0.763806 10%=0.764922 median=0.765218 90%=0.803925 max=0.803925)
sum median effective algorithm bandwidth: 0.487 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.046 seconds
algorithm times (in seconds) - 10 values (min=0.0572264 10%=0.0572686 median=0.0609862 90%=0.104097 max=0.104097)
sum median effective algorithm bandwidth: 6.108 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.037 seconds
algorithm times (in seconds) - 10 values (min=0.0661149 10%=0.0662294 median=0.068379 90%=0.106392 max=0.106392)
sum median effective algorithm bandwidth: 5.448 GB/s
</pre>

</p></details>