### PR TITLE
Task02  Тимофей Зиненко  Код Тех  закончил (МФТИ)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 build*
 cmake-build*
 .vs
+.vscode/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(GPGPUTasks)
 set(CMAKE_CXX_STANDARD 17)
 
 # Если вы установили CUDA SDK - можете включить поддержку CUDA
-option(GPU_CUDA_SUPPORT "CUDA support." OFF)
+option(GPU_CUDA_SUPPORT "CUDA support." ON)
 
 # GLSLC_BIN используйтся для компиляции Vulkan шейдеров (GLSL)
 if (NOT DEFINED GLSLC_BIN)

--- a/src/kernels/cu/mandelbrot.cu
+++ b/src/kernels/cu/mandelbrot.cu
@@ -1,27 +1,56 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
-#include "helpers/rassert.cu"
 #include "../defines.h"
+#include "helpers/rassert.cu"
 
 __global__ void mandelbrot(float* results,
-                        unsigned int width, unsigned int height,
-                        float fromX, float fromY,
-                        float sizeX, float sizeY,
-                        unsigned int iters, unsigned int isSmoothing)
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, unsigned int isSmoothing)
 {
     const unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // TODO
+    if (i >= width || j >= height) {
+        return;
+    }
+
+    float cx = fromX + i * (sizeX / width);
+    float cy = fromY + j * (sizeY / height);
+
+    float x = 0.0f;
+    float y = 0.0f;
+    float x2 = 0.0f;
+    float y2 = 0.0f;
+    unsigned int iteration = 0;
+
+    while (x2 + y2 <= 4.0f && iteration < iters) {
+        y = 2.0f * x * y + cy;
+        x = x2 - y2 + cx;
+        x2 = x * x;
+        y2 = y * y;
+        iteration++;
+    }
+
+    unsigned int index = j * width + i;
+
+    if (isSmoothing && iteration < iters) {
+        float log_zn = logf(x2 + y2) / 2.0f;
+        float nu = logf(log_zn / logf(2.0f)) / logf(2.0f);
+        results[index] = iteration + 1.0f - nu;
+    } else {
+        results[index] = (float)iteration;
+    }
 }
 
 namespace cuda {
-void mandelbrot(const gpu::WorkSize &workSize,
-    const gpu::gpu_mem_32f &results,
+void mandelbrot(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32f& results,
     unsigned int width, unsigned int height,
     float fromX, float fromY,
     float sizeX, float sizeY,

--- a/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
+++ b/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
@@ -1,6 +1,6 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
@@ -9,7 +9,7 @@
 __global__ void sum_03_local_memory_atomic_per_workgroup(
     const unsigned int* a,
     unsigned int* sum,
-    unsigned int  n)
+    unsigned int n)
 {
     // Подсказки:
     // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -17,12 +17,34 @@ __global__ void sum_03_local_memory_atomic_per_workgroup(
     // __shared__ unsigned int local_data[GROUP_SIZE];
     // __syncthreads();
 
-    // TODO
+    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
+
+    unsigned int partial_sum = 0;
+
+    for (uint i = index; i < n; i += blockDim.x * gridDim.x) {
+        partial_sum += a[i];
+    }
+
+    local_data[local_index] = partial_sum;
+    __syncthreads();
+
+    for (uint s = blockDim.x / 2; s > 0; s /= 2) {
+        if (local_index < s) {
+            local_data[local_index] += local_data[local_index + s];
+        }
+        __syncthreads();
+    }
+
+    if (local_index == 0) {
+        atomicAdd(sum, local_data[0]);
+    }
 }
 
 namespace cuda {
-void sum_03_local_memory_atomic_per_workgroup(const gpu::WorkSize &workSize,
-    const gpu::gpu_mem_32u &a, gpu::gpu_mem_32u &sum, unsigned int n)
+void sum_03_local_memory_atomic_per_workgroup(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32u& a, gpu::gpu_mem_32u& sum, unsigned int n)
 {
     gpu::Context context;
     rassert(context.type() == gpu::Context::TypeCUDA, 6573652345243, context.type());

--- a/src/kernels/cu/sum_04_local_reduction.cu
+++ b/src/kernels/cu/sum_04_local_reduction.cu
@@ -1,6 +1,6 @@
 #include <libgpu/context.h>
-#include <libgpu/work_size.h>
 #include <libgpu/shared_device_buffer.h>
+#include <libgpu/work_size.h>
 
 #include <libgpu/cuda/cu/common.cu>
 
@@ -11,7 +11,7 @@
 __global__ void sum_04_local_reduction(
     const unsigned int* a,
     unsigned int* b,
-    unsigned int  n)
+    unsigned int n)
 {
     // Подсказки:
     // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
@@ -19,12 +19,45 @@ __global__ void sum_04_local_reduction(
     // __shared__ unsigned int local_data[GROUP_SIZE];
     // __syncthreads();
 
-    // TODO
+    const unsigned int index = blockIdx.x * blockDim.x + threadIdx.x;
+    const unsigned int local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
+
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    __syncthreads();
+
+    for (unsigned int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (local_index < s) {
+            local_data[local_index] += local_data[local_index + s];
+        }
+        __syncthreads();
+    }
+
+    if (local_index == 0) {
+        b[blockIdx.x] = local_data[0];
+    }
+
+    __shared__ unsigned int final_sum;
+
+    if (local_index == 0 && blockIdx.x == 0) {
+        final_sum = local_data[0];
+
+        for (unsigned int block = 1; block < gridDim.x; block++) {
+            __threadfence();
+            final_sum += b[block];
+        }
+
+        b[0] = final_sum;
+    }
 }
 
 namespace cuda {
-void sum_04_local_reduction(const gpu::WorkSize &workSize,
-    const gpu::gpu_mem_32u &a, gpu::gpu_mem_32u &sum, unsigned int n)
+void sum_04_local_reduction(const gpu::WorkSize& workSize,
+    const gpu::gpu_mem_32u& a, gpu::gpu_mem_32u& sum, unsigned int n)
 {
     gpu::Context context;
     rassert(context.type() == gpu::Context::TypeCUDA, 6573652345243, context.type());

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -1,9 +1,9 @@
+#include <libbase/omp_utils.h>
 #include <libbase/stats.h>
 #include <libbase/timer.h>
-#include <libutils/misc.h>
-#include <libimages/images.h>
-#include <libbase/omp_utils.h>
 #include <libgpu/vulkan/engine.h>
+#include <libimages/images.h>
+#include <libutils/misc.h>
 
 #include "kernels/defines.h"
 #include "kernels/kernels.h"
@@ -11,16 +11,16 @@
 #include <fstream>
 
 void cpu::mandelbrot(float* results,
-                   unsigned int width, unsigned int height,
-                   float fromX, float fromY,
-                   float sizeX, float sizeY,
-                   unsigned int iters, unsigned int isSmoothing,
-                   bool useOpenMP)
+    unsigned int width, unsigned int height,
+    float fromX, float fromY,
+    float sizeX, float sizeY,
+    unsigned int iters, unsigned int isSmoothing,
+    bool useOpenMP)
 {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
 
-    #pragma omp parallel for if(useOpenMP)
+#pragma omp parallel for if (useOpenMP)
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -55,10 +55,10 @@ void run(int argc, char** argv)
 {
     gpu::Device device = gpu::chooseGPUDevice(gpu::selectAllDevices(ALL_GPUS, true), argc, argv);
 
-    // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
-    // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
-    // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    // 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
+    // 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
+    // 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -116,7 +116,8 @@ void run(int argc, char** argv)
                 cpu::mandelbrot(current_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing, false);
                 cpu_results = current_results;
             } else if (algorithm == "CPU with OpenMP") {
-                if (iter == 0) std::cout << "OpenMP threads: x" << getOpenMPThreadsCount() << " threads" << std::endl;
+                if (iter == 0)
+                    std::cout << "OpenMP threads: x" << getOpenMPThreadsCount() << " threads" << std::endl;
                 cpu::mandelbrot(current_results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing, true);
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
@@ -126,17 +127,25 @@ void run(int argc, char** argv)
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
-                    // TODO cuda::mandelbrot(..);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-
+                    // cuda::mandelbrot(..);
+                    cuda::mandelbrot(gpu::WorkSize(16, 16, (width + 15) / 16, (height + 15) / 16),
+                        gpu_results, width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit, isSmoothing);
+                    gpu_results.readN(current_results.ptr(), width * height);
                     // _______________________________Vulkan_________________________________________
                 } else if (context.type() == gpu::Context::TypeVulkan) {
                     typedef unsigned int uint;
                     struct {
-                        uint width; uint height;
-                       float fromX; float fromY;
-                       float sizeX; float sizeY;
-                        uint iters; uint isSmoothing;
+                        uint width;
+                        uint height;
+                        float fromX;
+                        float fromY;
+                        float sizeX;
+                        float sizeY;
+                        uint iters;
+                        uint isSmoothing;
                     } params = { width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing };
                     // TODO vk_mandelbrot.exec(params, ...);
                     throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
@@ -156,7 +165,7 @@ void run(int argc, char** argv)
         // Вычисляем достигнутую эффективную пропускную способность алгоритма (из соображений что мы все итерации делались полностью, без быстрого выхода через break)
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "Mandelbrot effective algorithm GFlops: " << maxApproximateFlops / gflops / stats::median(times) << " GFlops" << std::endl;
 
         // Сохраняем картинку
@@ -209,40 +218,53 @@ int main(int argc, char** argv)
 }
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+    vec3f(float x, float y, float z)
+        : x(x)
+        , y(y)
+        , z(z)
+    {
+    }
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
-vec3f operator+(const vec3f &a, const vec3f &b) {
-    return {a.x + b.x, a.y + b.y, a.z + b.z};
+vec3f operator+(const vec3f& a, const vec3f& b)
+{
+    return { a.x + b.x, a.y + b.y, a.z + b.z };
 }
 
-vec3f operator*(const vec3f &a, const vec3f &b) {
-    return {a.x * b.x, a.y * b.y, a.z * b.z};
+vec3f operator*(const vec3f& a, const vec3f& b)
+{
+    return { a.x * b.x, a.y * b.y, a.z * b.z };
 }
 
-vec3f operator*(const vec3f &a, float t) {
-    return {a.x * t, a.y * t, a.z * t};
+vec3f operator*(const vec3f& a, float t)
+{
+    return { a.x * t, a.y * t, a.z * t };
 }
 
-vec3f operator*(float t, const vec3f &a) {
+vec3f operator*(float t, const vec3f& a)
+{
     return a * t;
 }
 
-vec3f sin(const vec3f &a) {
-    return {sinf(a.x), sinf(a.y), sinf(a.z)};
+vec3f sin(const vec3f& a)
+{
+    return { sinf(a.x), sinf(a.y), sinf(a.z) };
 }
 
-vec3f cos(const vec3f &a) {
-    return {cosf(a.x), cosf(a.y), cosf(a.z)};
+vec3f cos(const vec3f& a)
+{
+    return { cosf(a.x), cosf(a.y), cosf(a.z) };
 }
 
 image8u renderToColor(const float* results, unsigned int width, unsigned int height)
 {
     image8u image(width, height, 3);
-    unsigned char *img_rgb = image.ptr();
-    #pragma omp parallel for
+    unsigned char* img_rgb = image.ptr();
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -251,10 +273,10 @@ image8u renderToColor(const float* results, unsigned int width, unsigned int hei
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
-            img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
-            img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
-            img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
+            img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char)(color.x * 255);
+            img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char)(color.y * 255);
+            img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char)(color.z * 255);
         }
     }
     return image;

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -23,7 +23,7 @@ unsigned int cpu::sum(const unsigned int* values, unsigned int n)
 unsigned int cpu::sumOpenMP(const unsigned int* values, unsigned int n)
 {
     unsigned int sum = 0;
-    #pragma omp parallel for schedule(dynamic, 1024) reduction(+ : sum)
+#pragma omp parallel for schedule(dynamic, 1024) reduction(+ : sum)
     for (ptrdiff_t i = 0; i < n; ++i) {
         sum += values[i];
     }
@@ -34,10 +34,10 @@ void run(int argc, char** argv)
 {
     gpu::Device device = gpu::chooseGPUDevice(gpu::selectAllDevices(ALL_GPUS, true), argc, argv);
 
-    // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
-    // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
-    // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    // 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
+    // 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
+    // 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -73,9 +73,19 @@ void run(int argc, char** argv)
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
     input_gpu.writeN(values.data(), n);
-    // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
-    // TODO 2) сделайте замер хотя бы три раза
-    // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    // 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
+    // 2) сделайте замер хотя бы три раза
+    // 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    {
+        std::vector<double> times;
+        for (int iter = 0; iter < 10; ++iter) {
+            timer t;
+            input_gpu.writeN(values.data(), n);
+            times.push_back(t.elapsed());
+        }
+        double memory_size_gb = sizeof(unsigned int) * n / 1024.0 / 1024.0 / 1024.0;
+        std::cout << "PCI-E upload median bandwidth: " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
+    }
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -132,11 +142,13 @@ void run(int argc, char** argv)
                         cuda::sum_02_atomics_load_k(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO cuda::sum_03_local_memory_atomic_per_workgroup(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        cuda::sum_03_local_memory_atomic_per_workgroup(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO cuda::sum_04_local_reduction(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
Локальный вывод 
<pre>
$ ./main_mandelbrot 1
Found 3 GPUs in 0.242471 sec (CUDA: 0.0313648 sec, OpenCL: 0.0849465 sec, Vulkan: 0.126044 sec)
Available devices:
  Device #0: API: OpenCL. CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 64161 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5201/7785 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 64161/64161 Mb.
Using device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5197/7785 Mb.
Using CUDA API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=4.06509 10%=4.06509 median=4.06509 90%=4.06509 max=4.06509)
Mandelbrot effective algorithm GFlops: 2.45997 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x56 threads
algorithm times (in seconds) - 10 values (min=0.116501 10%=0.119972 median=0.127236 90%=0.153117 max=0.153117)
Mandelbrot effective algorithm GFlops: 78.5942 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
algorithm times (in seconds) - 10 values (min=0.00346657 10%=0.00346696 median=0.00370729 90%=0.0866269 max=0.0866269)
Mandelbrot effective algorithm GFlops: 2697.39 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 117.157%
Error: Too high difference between CPU and GPU results!

$ ./main_sum 1
Found 3 GPUs in 0.359639 sec (CUDA: 0.0333758 sec, OpenCL: 0.0912619 sec, Vulkan: 0.234887 sec)
Available devices:
  Device #0: API: OpenCL. CPU. Intel(R) Xeon(R) CPU E5-2680 v4 @ 2.40GHz. Intel(R) Corporation. Total memory: 64161 Mb.
  Device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5195/7785 Mb.
  Device #2: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 64161/64161 Mb.
Using device #1: API: CUDA+OpenCL+Vulkan. GPU. Quadro RTX 4000 (CUDA 12080). Free memory: 5191/7785 Mb.
Using CUDA API...
PCI-E upload median bandwidth: 4.74678 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.260673 10%=0.262648 median=0.266048 90%=0.2727 max=0.2727)
sum median effective algorithm bandwidth: 1.40023 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0239607 10%=0.0241204 median=0.025443 90%=0.0306184 max=0.0306184)
sum median effective algorithm bandwidth: 14.6417 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
algorithm times (in seconds) - 10 values (min=0.00422713 10%=0.00433266 median=0.00468077 90%=0.00566176 max=0.00566176)
sum median effective algorithm bandwidth: 79.5871 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
algorithm times (in seconds) - 10 values (min=0.00223688 10%=0.00227955 median=0.00248739 90%=0.00276203 max=0.00276203)
sum median effective algorithm bandwidth: 149.767 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
algorithm times (in seconds) - 10 values (min=0.00756432 10%=0.00764548 median=0.00865327 90%=0.0107517 max=0.0107517)
sum median effective algorithm bandwidth: 43.0507 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
algorithm times (in seconds) - 10 values (min=0.118893 10%=0.120074 median=0.120602 90%=0.224131 max=0.224131)
sum median effective algorithm bandwidth: 3.08891 GB/s
</pre>