### PR TITLE
Task02 Roman Kremer ITMO

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -14,6 +14,33 @@ __kernel void mandelbrot(__global float* results,
 {
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
+    if (j >= height || i >= width) {
+        return;
+    }
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -10,10 +10,25 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
                                                        const unsigned int n)
 {
     // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int i = GROUP_SIZE / 2; i > 0; i /= 2) {
+        if (local_index < i) {
+            local_data[local_index] += local_data[local_index + i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (local_index == 0) {
+        atomic_add(sum, local_data[0]);
+    }
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -12,10 +12,25 @@ __kernel void sum_04_local_reduction(__global const uint* a,
                                             unsigned int  n)
 {
     // Подсказки:
-    // const uint index = get_global_id(0);
-    // const uint local_index = get_local_id(0);
-    // __local uint local_data[GROUP_SIZE];
-    // barrier(CLK_LOCAL_MEM_FENCE);
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (int i = GROUP_SIZE / 2; i > 0; i /= 2) {
+        if (local_index < i) {
+            local_data[local_index] += local_data[local_index + i];
+        }
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
+
+    if (local_index == 0) {
+        b[index / GROUP_SIZE] = local_data[0];
+    }
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -121,12 +121,13 @@ void run(int argc, char** argv)
             } else if (algorithm == "GPU") {
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
-                    // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, height, width);
+                    ocl_mandelbrot.exec(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
                     // TODO cuda::mandelbrot(..);
+                    // No NVIDIA ToT
                     throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
                     // _______________________________Vulkan_________________________________________
@@ -139,6 +140,8 @@ void run(int argc, char** argv)
                         uint iters; uint isSmoothing;
                     } params = { width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing };
                     // TODO vk_mandelbrot.exec(params, ...);
+                    // "Device 12th Gen Intel(R) Code(TM) i5-12450H doesn't support Vulkan"
+                    // ToT
                     throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
                 } else {
                     rassert(false, 546345243, context.type());

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -72,10 +72,16 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u reduction_buffer2_gpu(div_ceil(n, (unsigned int)GROUP_SIZE));
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    input_gpu.writeN(values.data(), n);
     // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
     // TODO 2) сделайте замер хотя бы три раза
     // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    std::vector<double> times;
+    for (size_t i = 0; i < 3; ++i) {
+        timer t;
+        input_gpu.writeN(values.data(), n);
+        times.push_back(t.elapsed());
+    }
+    std::cout << "PCI brandwidth: " << n * sizeof(unsigned int) / 1024.0 / 1024.0 / 1024.0 / stats::median(times) << " GB/s" << std::endl;
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -113,49 +119,20 @@ void run(int argc, char** argv)
                         ocl_sum02AtomicsLoadK.exec(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO ocl_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else {
-                        rassert(false, 652345234321, algorithm, algorithm_index);
-                    }
-                    // _______________________________CUDA___________________________________________
-                } else if (context.type() == gpu::Context::TypeCUDA) {
-                    if (algorithm == "01 atomicAdd from each workItem") {
-                        sum_accum_gpu.fill(0);
-                        cuda::sum_01_atomics(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "02 atomicAdd but each workItem loads K values") {
-                        sum_accum_gpu.fill(0);
-                        cuda::sum_02_atomics_load_k(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO cuda::sum_03_local_memory_atomic_per_workgroup(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else if (algorithm == "04 local reduction") {
-                        // TODO cuda::sum_04_local_reduction(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else {
-                        rassert(false, 652345234321, algorithm, algorithm_index);
-                    }
-                    // _______________________________Vulkan_________________________________________
-                } else if (context.type() == gpu::Context::TypeVulkan) {
-                    if (algorithm == "01 atomicAdd from each workItem") {
-                        sum_accum_gpu.fill(0);
-                        vk_sum01Atomics.exec(n, gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "02 atomicAdd but each workItem loads K values") {
-                        sum_accum_gpu.fill(0);
-                        vk_sum02AtomicsLoadK.exec(n, gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu);
-                        sum_accum_gpu.readN(&gpu_sum, 1);
-                    } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO vk_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
-                    } else if (algorithm == "04 local reduction") {
-                        // TODO vk_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        reduction_buffer1_gpu.fill(0);
+                        ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, n), input_gpu, reduction_buffer1_gpu, n);
+                        unsigned int i = (n - 1) / GROUP_SIZE + 1;
+                        while (i > 1) {
+                            reduction_buffer2_gpu.fill(0);
+                            ocl_sum04LocalReduction.exec(gpu::WorkSize(GROUP_SIZE, i), reduction_buffer1_gpu, reduction_buffer2_gpu, i);
+                            i = (i - 1) / GROUP_SIZE + 1;
+                            std::swap(reduction_buffer1_gpu, reduction_buffer2_gpu);
+                        }
+                        reduction_buffer1_gpu.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Local</summary><p>
<pre>
$ ./main_sum 0
Found 2 GPUs in 0.483443 sec (OpenCL: 0.260806 sec, Vulkan: 0.222318 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12450H. Intel(R) Corporation. Total memory: 7801 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 7801/7801 Mb.
Using device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12450H. Intel(R) Corporation. Total memory: 7801 Mb.
Using OpenCL API...
PCI brandwidth: 18.3516 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.180503 10%=0.183866 median=0.201214 90%=0.21175 max=0.21175)
sum median effective algorithm bandwidth: 1.8514 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0152269 10%=0.0154597 median=0.0212842 90%=0.0518879 max=0.0518879)
sum median effective algorithm bandwidth: 17.5026 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.269474 seconds
algorithm times (in seconds) - 10 values (min=1.84703 10%=1.84815 median=1.85147 90%=2.12928 max=2.12928)
sum median effective algorithm bandwidth: 0.201207 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0464667 seconds
algorithm times (in seconds) - 10 values (min=0.901722 10%=0.902307 median=0.911132 90%=0.950133 max=0.950133)
sum median effective algorithm bandwidth: 0.408864 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0740305 seconds
algorithm times (in seconds) - 10 values (min=0.0989006 10%=0.101181 median=0.104474 90%=0.170826 max=0.170826)
sum median effective algorithm bandwidth: 3.56577 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0534455 seconds
algorithm times (in seconds) - 10 values (min=0.10355 10%=0.10586 median=0.108209 90%=0.161365 max=0.161365)
sum median effective algorithm bandwidth: 3.44267 GB/s

$ ./main_mandelbrot 0
Found 2 GPUs in 0.0966079 sec (OpenCL: 0.0479595 sec, Vulkan: 0.0486033 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12450H. Intel(R) Corporation. Total memory: 7801 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 7801/7801 Mb.
Using device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i5-12450H. Intel(R) Corporation. Total memory: 7801 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.73357 10%=2.73357 median=2.73357 90%=2.73357 max=2.73357)
Mandelbrot effective algorithm GFlops: 3.65823 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x12 threads
algorithm times (in seconds) - 10 values (min=0.348386 10%=0.369756 median=0.384209 90%=0.408695 max=0.408695)
Mandelbrot effective algorithm GFlops: 26.0275 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.120904 seconds
algorithm times (in seconds) - 10 values (min=0.0561389 10%=0.0563135 median=0.0566065 90%=0.183214 max=0.183214)
Mandelbrot effective algorithm GFlops: 176.658 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%
</pre>
</p></details>

<details><summary>GitHub</summary><p>
<pre>
./main_sum 0
Found 2 GPUs in 0.0439725 sec (CUDA: 8.0019e-05 sec, OpenCL: 0.0196192 sec, Vulkan: 0.0242297 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCI brandwidth: 13.889 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0327886 10%=0.0328226 median=0.0329078 90%=0.0441979 max=0.0441979)
sum median effective algorithm bandwidth: 11.3204 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0259901 10%=0.0259993 median=0.0309295 90%=0.0369941 max=0.0369941)
sum median effective algorithm bandwidth: 12.0445 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.109176 seconds
algorithm times (in seconds) - 10 values (min=1.48999 10%=1.49055 median=1.49135 90%=1.63428 max=1.63428)
sum median effective algorithm bandwidth: 0.249793 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0295081 seconds
algorithm times (in seconds) - 10 values (min=0.748127 10%=0.749016 median=0.749642 90%=0.779807 max=0.779807)
sum median effective algorithm bandwidth: 0.496943 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0693373 seconds
algorithm times (in seconds) - 10 values (min=0.494681 10%=0.494827 median=0.495388 90%=0.564937 max=0.564937)
sum median effective algorithm bandwidth: 0.751995 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0578857 seconds
algorithm times (in seconds) - 10 values (min=0.492121 10%=0.492387 median=0.49333 90%=0.553677 max=0.553677)
sum median effective algorithm bandwidth: 0.755131 GB/s

./main_mandelbrot 0
Found 2 GPUs in 0.0433233 sec (CUDA: 7.6332e-05 sec, OpenCL: 0.0195645 sec, Vulkan: 0.0236222 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00043 10%=2.00043 median=2.00043 90%=2.00043 max=2.00043)
Mandelbrot effective algorithm GFlops: 4.99892 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.606898 10%=0.606973 median=0.60713 90%=0.609149 max=0.609149)
Mandelbrot effective algorithm GFlops: 16.4709 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.162405 seconds
algorithm times (in seconds) - 10 values (min=0.151644 10%=0.151671 median=0.151778 90%=0.316001 max=0.316001)
Mandelbrot effective algorithm GFlops: 65.8856 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%
</pre>
</p></details>