### PR TITLE
Task02 Владимир Васенев HSE

### DIFF
--- a/src/kernels/cu/mandelbrot.cu
+++ b/src/kernels/cu/mandelbrot.cu
@@ -16,7 +16,31 @@ __global__ void mandelbrot(float* results,
     const unsigned int i = blockIdx.x * blockDim.x + threadIdx.x;
     const unsigned int j = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }
 
 namespace cuda {

--- a/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
+++ b/src/kernels/cu/sum_03_local_memory_atomic_per_workgroup.cu
@@ -11,13 +11,25 @@ __global__ void sum_03_local_memory_atomic_per_workgroup(
     unsigned int* sum,
     unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
+    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    __syncthreads();
+
+    if (local_index == 0) {
+        unsigned int total = 0;
+        for (int i = 0; i < GROUP_SIZE; ++i) {
+            total += local_data[i];
+        }
+        atomicAdd(sum, total);
+    }
 }
 
 namespace cuda {

--- a/src/kernels/cu/sum_04_local_reduction.cu
+++ b/src/kernels/cu/sum_04_local_reduction.cu
@@ -13,13 +13,25 @@ __global__ void sum_04_local_reduction(
     unsigned int* b,
     unsigned int  n)
 {
-    // Подсказки:
-    // const uint index = blockIdx.x * blockDim.x + threadIdx.x;
-    // const uint local_index = threadIdx.x;
-    // __shared__ unsigned int local_data[GROUP_SIZE];
-    // __syncthreads();
+    const uint index = blockIdx.x * blockDim.x + threadIdx.x;
+    const uint local_index = threadIdx.x;
+    __shared__ unsigned int local_data[GROUP_SIZE];
 
-    // TODO
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    __syncthreads();
+
+    if (local_index == 0) {
+        unsigned int total = 0;
+        for (int i = 0; i < GROUP_SIZE; ++i) {
+           total += local_data[i];
+        }
+        b[index / GROUP_SIZE] = total;
+    }
 }
 
 namespace cuda {

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -4,6 +4,7 @@
 #include <libimages/images.h>
 #include <libbase/omp_utils.h>
 #include <libgpu/vulkan/engine.h>
+#include <libgpu/shared_device_image.h>
 
 #include "kernels/defines.h"
 #include "kernels/kernels.h"
@@ -58,7 +59,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -126,8 +127,9 @@ void run(int argc, char** argv)
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {
-                    // TODO cuda::mandelbrot(..);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    cuda::mandelbrot(workSize, gpu_results, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, isSmoothing);
+                    // throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
                     // _______________________________Vulkan_________________________________________
                 } else if (context.type() == gpu::Context::TypeVulkan) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -37,7 +37,7 @@ void run(int argc, char** argv)
     // TODO 000 сделайте здесь свой выбор API - если он отличается от OpenCL то в этой строке нужно заменить TypeOpenCL на TypeCUDA или TypeVulkan
     // TODO 000 после этого изучите этот код, запустите его, изучите соответсвующий вашему выбору кернел - src/kernels/<ваш выбор>/aplusb.<ваш выбор>
     // TODO 000 P.S. если вы выбрали CUDA - не забудьте установить CUDA SDK и добавить -DCUDA_SUPPORT=ON в CMake options
-    gpu::Context context = activateContext(device, gpu::Context::TypeOpenCL);
+    gpu::Context context = activateContext(device, gpu::Context::TypeCUDA);
     // OpenCL - рекомендуется как вариант по умолчанию, можно выполнять на CPU, есть printf, есть аналог valgrind/cuda-memcheck - https://github.com/jrprice/Oclgrind
     // CUDA   - рекомендуется если у вас NVIDIA видеокарта, есть printf, т.к. в таком случае вы сможете пользоваться профилировщиком (nsight-compute) и санитайзером (compute-sanitizer, это бывший cuda-memcheck)
     // Vulkan - не рекомендуется, т.к. писать код (compute shaders) на шейдерном языке GLSL на мой взгляд менее приятно чем в случае OpenCL/CUDA
@@ -76,6 +76,14 @@ void run(int argc, char** argv)
     // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
     // TODO 2) сделайте замер хотя бы три раза
     // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    std::vector<double> pci_times;
+    for (size_t i = 0; i < 5; ++i) {
+        timer t;
+        input_gpu.writeN(values.data(), n);
+        pci_times.push_back(t.elapsed());
+    }
+
+    std::cout << "PCI-E median bandwidth: " << n * sizeof(unsigned int) / 1024. / 1024 / 1024 / stats::median(pci_times) << " GB/s" << std::endl;
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -132,11 +140,16 @@ void run(int argc, char** argv)
                         cuda::sum_02_atomics_load_k(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO cuda::sum_03_local_memory_atomic_per_workgroup(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        cuda::sum_03_local_memory_atomic_per_workgroup(gpu::WorkSize(GROUP_SIZE, n), input_gpu, sum_accum_gpu, n);
+                        sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO cuda::sum_04_local_reduction(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, n), input_gpu, reduction_buffer1_gpu, n);
+                        for (unsigned int i = div_ceil(n, (unsigned int)GROUP_SIZE); i > 1; i = div_ceil(i, (unsigned int)GROUP_SIZE)) {
+                            cuda::sum_04_local_reduction(gpu::WorkSize(GROUP_SIZE, i), reduction_buffer1_gpu, reduction_buffer2_gpu, i);  
+                            reduction_buffer2_gpu.copyToN(reduction_buffer1_gpu, i);
+                        }
+                        reduction_buffer1_gpu.readN(&gpu_sum, 1);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION

<details><summary>Локальный вывод</summary><p>

<pre>
ubuntu@weak-gpu-resources:~/GPGPUTasks2025/build$ ./main_mandelbrot 
Found 1 GPUs in 0.348386 sec (CUDA: 0.185646 sec, OpenCL: 0.0314586 sec, Vulkan: 0.131221 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 2080 Ti (CUDA 12080). Free memory: 10653/10822 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 2080 Ti (CUDA 12080). Free memory: 10653/10822 Mb.
Using CUDA API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=3.51421 10%=3.51421 median=3.51421 90%=3.51421 max=3.51421)
Mandelbrot effective algorithm GFlops: 2.84559 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x8 threads
algorithm times (in seconds) - 10 values (min=0.533858 10%=0.534002 median=0.535483 90%=0.544133 max=0.544133)
Mandelbrot effective algorithm GFlops: 18.6747 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
algorithm times (in seconds) - 10 values (min=0.00111946 10%=0.00111949 median=0.00112143 90%=0.00141116 max=0.00141116)
Mandelbrot effective algorithm GFlops: 8917.23 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

ubuntu@weak-gpu-resources:~/GPGPUTasks2025/build$ ./main_sum 
Found 1 GPUs in 0.364468 sec (CUDA: 0.191873 sec, OpenCL: 0.0317645 sec, Vulkan: 0.140776 sec)
Available devices:
  Device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 2080 Ti (CUDA 12080). Free memory: 10653/10822 Mb.
Using device #0: API: CUDA+OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 2080 Ti (CUDA 12080). Free memory: 10653/10822 Mb.
Using CUDA API...
PCI-E median bandwidth: 3.99322 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.202469 10%=0.203329 median=0.206429 90%=0.207351 max=0.207351)
sum median effective algorithm bandwidth: 1.80464 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0288209 10%=0.0289645 median=0.0290773 90%=0.0298797 max=0.0298797)
sum median effective algorithm bandwidth: 12.8117 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
algorithm times (in seconds) - 10 values (min=0.0025855 10%=0.00258592 median=0.00258763 90%=0.00292614 max=0.00292614)
sum median effective algorithm bandwidth: 143.965 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
algorithm times (in seconds) - 10 values (min=0.0013628 10%=0.00136318 median=0.00136647 90%=0.00169641 max=0.00169641)
sum median effective algorithm bandwidth: 272.621 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
algorithm times (in seconds) - 10 values (min=0.00152481 10%=0.00152747 median=0.0015315 90%=0.00181074 max=0.00181074)
sum median effective algorithm bandwidth: 243.244 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
algorithm times (in seconds) - 10 values (min=0.00156178 10%=0.00156216 median=0.00156535 90%=0.00182696 max=0.00182696)
sum median effective algorithm bandwidth: 237.985 GB/s
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot
...

$ ./main_sum
...
</pre>

</p></details>
