### PR TITLE
Task02 Савва Пичугин HSE

### DIFF
--- a/src/kernels/cl/mandelbrot.cl
+++ b/src/kernels/cl/mandelbrot.cl
@@ -15,5 +15,30 @@ __kernel void mandelbrot(__global float* results,
     const unsigned int i = get_global_id(0);
     const unsigned int j = get_global_id(1);
 
-    // TODO
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    float x0 = fromX + (i + 0.5f) * sizeX / width;
+    float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (isSmoothing && iter != iters) {
+        result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
+    return;
 }

--- a/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
+++ b/src/kernels/cl/sum_03_local_memory_atomic_per_workgroup.cl
@@ -15,5 +15,25 @@ __kernel void sum_03_local_memory_atomic_per_workgroup(__global const uint* a,
     // __local uint local_data[GROUP_SIZE];
     // barrier(CLK_LOCAL_MEM_FENCE);
 
-    // TODO
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
+
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if(local_index == 0) {
+        uint master_thread_accumulator = 0;
+        for(int i = 0; i<GROUP_SIZE; ++i) {
+            master_thread_accumulator += local_data[i];
+        }
+        atomic_add(sum, master_thread_accumulator);
+    }
+
+    return;
 }

--- a/src/kernels/cl/sum_04_local_reduction.cl
+++ b/src/kernels/cl/sum_04_local_reduction.cl
@@ -17,5 +17,25 @@ __kernel void sum_04_local_reduction(__global const uint* a,
     // __local uint local_data[GROUP_SIZE];
     // barrier(CLK_LOCAL_MEM_FENCE);
 
-    // TODO
+    const uint index = get_global_id(0);
+    const uint local_index = get_local_id(0);
+    __local uint local_data[GROUP_SIZE];
+
+    if (index < n) {
+        local_data[local_index] = a[index];
+    } else {
+        local_data[local_index] = 0;
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if(local_index == 0) {
+        uint master_thread_accumulator = 0;
+        for(int i = 0; i<GROUP_SIZE; ++i) {
+            master_thread_accumulator += local_data[i];
+        }
+        b[get_group_id(0)] = master_thread_accumulator;
+    }
+
+    return;
 }

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -122,7 +122,16 @@ void run(int argc, char** argv)
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
                     // TODO ocl_mandelbrot.exec(...);
-                    throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                    gpu::WorkSize workSize(GROUP_SIZE_X, GROUP_SIZE_Y, width, height);
+                    ocl_mandelbrot.exec(
+                        workSize,
+                        gpu_results,
+                        width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
+                        sizeX, sizeY,
+                        iterationsLimit,
+                        isSmoothing);
+                    //throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
 
                     // _______________________________CUDA___________________________________________
                 } else if (context.type() == gpu::Context::TypeCUDA) {

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -72,10 +72,14 @@ void run(int argc, char** argv)
     gpu::gpu_mem_32u reduction_buffer2_gpu(div_ceil(n, (unsigned int)GROUP_SIZE));
 
     // Прогружаем входные данные по PCI-E шине: CPU RAM -> GPU VRAM
-    input_gpu.writeN(values.data(), n);
-    // TODO 1) замерьте здесь какая достигнута пропускная пособность PCI-E шины
-    // TODO 2) сделайте замер хотя бы три раза
-    // TODO 3) и выведите рассчет на основании медианного времени (в легко понятной форме - GB/s)
+    std::vector<double> times;
+    for (int i = 0; i<10; ++i) {
+        timer t;
+        input_gpu.writeN(values.data(), n);
+        times.push_back(t.elapsed());
+    }
+    double memory_size_gb = sizeof(unsigned int) * n / 1024.0 / 1024.0 / 1024.0;
+    std::cout<<"PCI-E bandwidth " << memory_size_gb / stats::median(times) << " GB/s" << std::endl;
 
     std::vector<std::string> algorithm_names = {
         "CPU",
@@ -113,11 +117,47 @@ void run(int argc, char** argv)
                         ocl_sum02AtomicsLoadK.exec(gpu::WorkSize(GROUP_SIZE, n / LOAD_K_VALUES_PER_ITEM), input_gpu, sum_accum_gpu, n);
                         sum_accum_gpu.readN(&gpu_sum, 1);
                     } else if (algorithm == "03 local memory and atomicAdd from master thread") {
-                        // TODO ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        sum_accum_gpu.fill(0);
+                        ocl_sum03LocalMemoryAtomicPerWorkgroup.exec(
+                                gpu::WorkSize(
+                                    GROUP_SIZE,
+                                    n
+                                ),
+                                input_gpu,
+                                sum_accum_gpu,
+                                n
+                        );
+                        sum_accum_gpu.readN(&gpu_sum, 1);
+                        //throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
                     } else if (algorithm == "04 local reduction") {
-                        // TODO ocl_sum04LocalReduction.exec(...);
-                        throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                        gpu::gpu_mem_32u* from = &input_gpu;
+                        gpu::gpu_mem_32u* to = &reduction_buffer1_gpu;
+                        to->fill(0);
+                        unsigned int next_n = n;
+                        bool flag = true;
+                        while (next_n>1) {
+                            ocl_sum04LocalReduction.exec(
+                                gpu::WorkSize(
+                                GROUP_SIZE,
+                                next_n
+                                ),
+                                *from,
+                                *to,
+                                next_n
+                            );
+                            next_n = div_ceil(next_n, (unsigned int)GROUP_SIZE);
+                            if (flag) {
+                                from = &reduction_buffer1_gpu;
+                                to = &reduction_buffer2_gpu;
+                                flag = false;
+                            } else {
+                                from = &reduction_buffer2_gpu;
+                                to = &reduction_buffer1_gpu;
+                                flag = true;
+                            }
+                        }
+                        from->readN(&gpu_sum, 1);
+                        //throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
                     } else {
                         rassert(false, 652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION

<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_mandelbrot
Found 3 GPUs in 1.48529 sec (OpenCL: 1.3105 sec, Vulkan: 0.173522 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i7-1280P. Intel(R) Corporation. Total memory: 16083 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) Iris(R) Xe Graphics. Free memory: 7383/6433 Mb.
  Device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU. Free memory: 3391/4095 Mb.
Using device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU. Free memory: 3391/4095 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.73954 10%=2.73954 median=2.73954 90%=2.73954 max=2.73954)
Mandelbrot effective algorithm GFlops: 3.65025 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x20 threads
algorithm times (in seconds) - 10 values (min=0.327795 10%=0.328968 median=0.353296 90%=0.39345 max=0.39345)
Mandelbrot effective algorithm GFlops: 28.3049 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.0229881 seconds
algorithm times (in seconds) - 10 values (min=0.0041777 10%=0.0041929 median=0.0042693 90%=0.0312841 max=0.0312841)
Mandelbrot effective algorithm GFlops: 2342.3 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

Process finished with exit code 0

$ ./main_sum
Found 3 GPUs in 1.36695 sec (OpenCL: 1.31812 sec, Vulkan: 0.048373 sec)
Available devices:
  Device #0: API: OpenCL. CPU. 12th Gen Intel(R) Core(TM) i7-1280P. Intel(R) Corporation. Total memory: 16083 Mb.
  Device #1: API: OpenCL+Vulkan. GPU. Intel(R) Iris(R) Xe Graphics. Free memory: 7383/6433 Mb.
  Device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU. Free memory: 3391/4095 Mb.
Using device #2: API: OpenCL+Vulkan. GPU. NVIDIA GeForce RTX 3050 Ti Laptop GPU. Free memory: 3391/4095 Mb.
Using OpenCL API...
PCI-E bandwidth 5.58011 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0567251 10%=0.0601897 median=0.0705494 90%=0.0980852 max=0.0980852)
sum median effective algorithm bandwidth: 5.2804 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.012188 10%=0.0134533 median=0.0142614 90%=0.0169344 max=0.0169344)
sum median effective algorithm bandwidth: 26.1215 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.0079726 seconds
algorithm times (in seconds) - 10 values (min=0.0029834 10%=0.0030187 median=0.0030753 90%=0.0119326 max=0.0119326)
sum median effective algorithm bandwidth: 121.136 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0045991 seconds
algorithm times (in seconds) - 10 values (min=0.0023626 10%=0.0023642 median=0.0024114 90%=0.0076188 max=0.0076188)
sum median effective algorithm bandwidth: 154.487 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0043334 seconds
algorithm times (in seconds) - 10 values (min=0.0107406 10%=0.0107784 median=0.0109373 90%=0.0158514 max=0.0158514)
sum median effective algorithm bandwidth: 34.0604 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0033816 seconds
algorithm times (in seconds) - 10 values (min=0.0099835 10%=0.0100852 median=0.010348 90%=0.014268 max=0.014268)
sum median effective algorithm bandwidth: 36.0001 GB/s

Process finished with exit code 0
</pre>

</p></details>



<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_mandelbrot
Found 2 GPUs in 0.0455411 sec (CUDA: 7.7245e-05 sec, OpenCL: 0.0207046 sec, Vulkan: 0.024715 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
______________________________________________________
Evaluating algorithm #1/3: CPU
algorithm times (in seconds) - 1 values (min=2.00014 10%=2.00014 median=2.00014 90%=2.00014 max=2.00014)
Mandelbrot effective algorithm GFlops: 4.99964 GFlops
saving image to 'mandelbrot CPU.bmp'...
CPU vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #2/3: CPU with OpenMP
OpenMP threads: x4 threads
algorithm times (in seconds) - 10 values (min=0.60214 10%=0.60226 median=0.607556 90%=0.787448 max=0.787448)
Mandelbrot effective algorithm GFlops: 16.4594 GFlops
saving image to 'mandelbrot CPU with OpenMP.bmp'...
CPU with OpenMP vs CPU average results difference: 0%
______________________________________________________
Evaluating algorithm #3/3: GPU
Kernels compilation done in 0.152484 seconds
algorithm times (in seconds) - 10 values (min=0.149418 10%=0.14943 median=0.14946 90%=0.304498 max=0.304498)
Mandelbrot effective algorithm GFlops: 66.9077 GFlops
saving image to 'mandelbrot GPU.bmp'...
GPU vs CPU average results difference: 0.942446%

$ ./main_sum
Found 2 GPUs in 0.0453593 sec (CUDA: 8e-05 sec, OpenCL: 0.02036 sec, Vulkan: 0.0248739 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15995/15995 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15995 Mb.
Using OpenCL API...
PCI-E bandwidth 15.3638 GB/s
______________________________________________________
Evaluating algorithm #1/6: CPU
algorithm times (in seconds) - 10 values (min=0.0328663 10%=0.0329242 median=0.0340859 90%=0.0399885 max=0.0399885)
sum median effective algorithm bandwidth: 10.9291 GB/s
______________________________________________________
Evaluating algorithm #2/6: CPU with OpenMP
algorithm times (in seconds) - 10 values (min=0.0213995 10%=0.0214371 median=0.021638 90%=0.0221181 max=0.0221181)
sum median effective algorithm bandwidth: 17.2164 GB/s
______________________________________________________
Evaluating algorithm #3/6: 01 atomicAdd from each workItem
Kernels compilation done in 0.109115 seconds
algorithm times (in seconds) - 10 values (min=1.54054 10%=1.54074 median=1.54185 90%=1.65166 max=1.65166)
sum median effective algorithm bandwidth: 0.241611 GB/s
______________________________________________________
Evaluating algorithm #4/6: 02 atomicAdd but each workItem loads K values
Kernels compilation done in 0.0294929 seconds
algorithm times (in seconds) - 10 values (min=0.769882 10%=0.771386 median=0.772464 90%=0.802225 max=0.802225)
sum median effective algorithm bandwidth: 0.482261 GB/s
______________________________________________________
Evaluating algorithm #5/6: 03 local memory and atomicAdd from master thread
Kernels compilation done in 0.0474518 seconds
algorithm times (in seconds) - 10 values (min=0.0570065 10%=0.0570436 median=0.0572433 90%=0.10533 max=0.10533)
sum median effective algorithm bandwidth: 6.50782 GB/s
______________________________________________________
Evaluating algorithm #6/6: 04 local reduction
Kernels compilation done in 0.0365264 seconds
algorithm times (in seconds) - 10 values (min=0.0654834 10%=0.0655831 median=0.0658035 90%=0.103753 max=0.103753)
sum median effective algorithm bandwidth: 5.66124 GB/s
</pre>

</p></details>