### PR TITLE
Task03 Denis Sokolov ITMO

### DIFF
--- a/src/kernels/cl/matrix_01_transpose_naive.cl
+++ b/src/kernels/cl/matrix_01_transpose_naive.cl
@@ -4,12 +4,18 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_01_transpose_naive(
                        __global const float* matrix,            // w x h
                        __global       float* transposed_matrix, // h x w
                                 unsigned int w,
                                 unsigned int h)
 {
-    // TODO
+    const uint i = get_global_id(0);
+    const uint j = get_global_id(1);
+
+    if (i >= w || j >= h)
+        return;
+
+    transposed_matrix[i * h + j] = matrix[j * w + i];
 }

--- a/src/kernels/cl/matrix_02_transpose_coalesced_via_local_memory.cl
+++ b/src/kernels/cl/matrix_02_transpose_coalesced_via_local_memory.cl
@@ -4,12 +4,34 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_02_transpose_coalesced_via_local_memory(
                        __global const float* matrix,            // w x h
                        __global       float* transposed_matrix, // h x w
                                 unsigned int w,
                                 unsigned int h)
 {
-    // TODO
+    const uint loc_i = get_local_id(0);
+    const uint loc_j = get_local_id(1);
+    const uint gr_i = get_group_id(0);
+    const uint gr_j = get_group_id(1);
+    const uint i = get_global_id(0);
+    const uint j = get_global_id(1);
+
+    __local float tile[GROUP_SIZE_X + 1][GROUP_SIZE_Y];
+
+    if (i < w && j < h) {
+        tile[loc_i][loc_j] = matrix[j * w + i];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    const uint new_gr_i = gr_j;
+    const uint new_gr_j = gr_i;
+    const uint new_i = new_gr_i * GROUP_SIZE_Y + loc_i;
+    const uint new_j = new_gr_j * GROUP_SIZE_X + loc_j;
+
+    if (new_i < h && new_j < w) {
+        transposed_matrix[new_j * h + new_i] = tile[loc_j][loc_i];
+    }
 }

--- a/src/kernels/cl/matrix_02_transpose_coalesced_via_local_memory.cl
+++ b/src/kernels/cl/matrix_02_transpose_coalesced_via_local_memory.cl
@@ -18,10 +18,10 @@ __kernel void matrix_02_transpose_coalesced_via_local_memory(
     const uint i = get_global_id(0);
     const uint j = get_global_id(1);
 
-    __local float tile[GROUP_SIZE_X + 1][GROUP_SIZE_Y];
+    __local float tile[GROUP_SIZE_Y][GROUP_SIZE_X + 1];
 
     if (i < w && j < h) {
-        tile[loc_i][loc_j] = matrix[j * w + i];
+        tile[loc_j][loc_i] = matrix[j * w + i];
     }
 
     barrier(CLK_LOCAL_MEM_FENCE);
@@ -32,6 +32,6 @@ __kernel void matrix_02_transpose_coalesced_via_local_memory(
     const uint new_j = new_gr_j * GROUP_SIZE_X + loc_j;
 
     if (new_i < h && new_j < w) {
-        transposed_matrix[new_j * h + new_i] = tile[loc_j][loc_i];
+        transposed_matrix[new_j * h + new_i] = tile[loc_i][loc_j];
     }
 }

--- a/src/kernels/cl/matrix_03_multiply_naive.cl
+++ b/src/kernels/cl/matrix_03_multiply_naive.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_03_multiply_naive(
                        __global const float* a, // rows=h x cols=k
                        __global const float* b, // rows=k x cols=w
@@ -13,5 +13,18 @@ __kernel void matrix_03_multiply_naive(
                                 unsigned int h,
                                 unsigned int k)
 {
-    // TODO
+    const uint i = get_global_id(0);
+    const uint j = get_global_id(1);
+
+    if (i >= w || j >= h) {
+        return;
+    }
+
+    float sum = 0.0f;
+
+    for (uint iter = 0; iter < k; ++iter) {
+        sum += a[j * k + iter] * b[iter * w + i];
+    }
+
+    c[j * w + i] = sum;
 }

--- a/src/kernels/cl/matrix_04_multiply_via_local_memory.cl
+++ b/src/kernels/cl/matrix_04_multiply_via_local_memory.cl
@@ -4,7 +4,7 @@
 
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
+__attribute__((reqd_work_group_size(GROUP_SIZE_X, GROUP_SIZE_Y, 1)))
 __kernel void matrix_04_multiply_via_local_memory(
                        __global const float* a, // rows=h x cols=k
                        __global const float* b, // rows=k x cols=w
@@ -13,5 +13,38 @@ __kernel void matrix_04_multiply_via_local_memory(
                                 unsigned int h,
                                 unsigned int k)
 {
-    // TODO
+    const uint loc_i = get_local_id(0);
+    const uint loc_j = get_local_id(1);
+    const uint i = get_global_id(0);
+    const uint j = get_global_id(1);
+
+    __local float tile_a[GROUP_SIZE_X + 1][GROUP_SIZE_Y];
+    __local float tile_b[GROUP_SIZE_X + 1][GROUP_SIZE_Y];
+
+    c[j * w + i] = 0.0f;
+
+    for (uint tile_k = 0; tile_k < k; tile_k += GROUP_SIZE_X) {
+        const uint col_a = tile_k + loc_i;
+        const uint row_b = tile_k / GROUP_SIZE_X * GROUP_SIZE_Y + loc_j;
+
+        if (j < h && col_a < k) {
+            tile_a[loc_i][loc_j] = a[j * k + col_a];
+        } else {
+            tile_a[loc_i][loc_j] = 0.0f;
+        }
+
+        if (i < w && row_b < k) {
+            tile_b[loc_i][loc_j] = b[row_b * w + i];
+        } else {
+            tile_b[loc_i][loc_j] = 0.0f;
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        for (uint acc_idx = 0; acc_idx < GROUP_SIZE_X; ++acc_idx) {
+            c[j * w + i] += tile_a[acc_idx][loc_j] * tile_b[loc_i][acc_idx];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+    }
 }

--- a/src/kernels/cl/matrix_04_multiply_via_local_memory.cl
+++ b/src/kernels/cl/matrix_04_multiply_via_local_memory.cl
@@ -18,8 +18,8 @@ __kernel void matrix_04_multiply_via_local_memory(
     const uint i = get_global_id(0);
     const uint j = get_global_id(1);
 
-    __local float tile_a[GROUP_SIZE_X + 1][GROUP_SIZE_Y];
-    __local float tile_b[GROUP_SIZE_X + 1][GROUP_SIZE_Y];
+    __local float tile_a[GROUP_SIZE_Y][GROUP_SIZE_X];
+    __local float tile_b[GROUP_SIZE_Y][GROUP_SIZE_X + 1];
 
     c[j * w + i] = 0.0f;
 
@@ -28,21 +28,21 @@ __kernel void matrix_04_multiply_via_local_memory(
         const uint row_b = tile_k / GROUP_SIZE_X * GROUP_SIZE_Y + loc_j;
 
         if (j < h && col_a < k) {
-            tile_a[loc_i][loc_j] = a[j * k + col_a];
+            tile_a[loc_j][loc_i] = a[j * k + col_a];
         } else {
-            tile_a[loc_i][loc_j] = 0.0f;
+            tile_a[loc_j][loc_i] = 0.0f;
         }
 
         if (i < w && row_b < k) {
-            tile_b[loc_i][loc_j] = b[row_b * w + i];
+            tile_b[loc_j][loc_i] = b[row_b * w + i];
         } else {
-            tile_b[loc_i][loc_j] = 0.0f;
+            tile_b[loc_j][loc_i] = 0.0f;
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);
 
         for (uint acc_idx = 0; acc_idx < GROUP_SIZE_X; ++acc_idx) {
-            c[j * w + i] += tile_a[acc_idx][loc_j] * tile_b[loc_i][acc_idx];
+            c[j * w + i] += tile_a[loc_j][acc_idx] * tile_b[acc_idx][loc_i];
         }
 
         barrier(CLK_LOCAL_MEM_FENCE);

--- a/src/main_01_matrix_transpose.cpp
+++ b/src/main_01_matrix_transpose.cpp
@@ -68,13 +68,12 @@ void run(int argc, char** argv)
         for (int iter = 0; iter < 10; ++iter) {
             timer t;
 
-            throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED); // TODO remove me
             // _______________________________OpenCL_____________________________________________
             if (context.type() == gpu::Context::TypeOpenCL) {
                 if (algorithm == "01 naive transpose (non-coalesced)") {
-                    ocl_matrix01TransposeNaive.exec(gpu::WorkSize(1, 1, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
+                    ocl_matrix01TransposeNaive.exec(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
                 } else if (algorithm == "02 transpose via local memory (coalesced)") {
-                    ocl_matrix02TransposeCoalescedViaLocalMemory.exec(gpu::WorkSize(1, 1, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
+                    ocl_matrix02TransposeCoalescedViaLocalMemory.exec(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, w, h), input_matrix_gpu, output_matrix_gpu, w, h);
                 } else {
                     rassert(false, 652345234321, algorithm, algorithm_index);
                 }

--- a/src/main_02_matrix_multiply.cpp
+++ b/src/main_02_matrix_multiply.cpp
@@ -126,13 +126,12 @@ void run(int argc, char** argv)
             if (algorithm == "CPU with OpenMP") {
                 cpu::multiply(input_a_cpu, input_b_cpu, output_c_cpu, w, h, k, true);
             } else {
-                throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED); // TODO remove me
                 // _______________________________OpenCL_____________________________________________
                 if (context.type() == gpu::Context::TypeOpenCL) {
                     if (algorithm == "01 naive") {
-                        ocl_matrix03MultiplyNaive.exec(gpu::WorkSize(1, 1, w, h), matrix_a_gpu, matrix_b_gpu, matrix_c_gpu, w, h, k);
+                        ocl_matrix03MultiplyNaive.exec(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, w, h), matrix_a_gpu, matrix_b_gpu, matrix_c_gpu, w, h, k);
                     } else if (algorithm == "02 using local memory") {
-                        ocl_matrix04MultiplyViaLocalMemory.exec(gpu::WorkSize(1, 1, w, h), matrix_a_gpu, matrix_b_gpu, matrix_c_gpu, w, h, k);
+                        ocl_matrix04MultiplyViaLocalMemory.exec(gpu::WorkSize(GROUP_SIZE_X, GROUP_SIZE_Y, w, h), matrix_a_gpu, matrix_b_gpu, matrix_c_gpu, w, h, k);
                     } else {
                         rassert(false, 7652345234321, algorithm, algorithm_index);
                     }


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_matrix_transpose
Found 2 GPUs in 0.216854 sec (OpenCL: 0.145116 sec, Vulkan: 0.0713244 sec)
Available devices:
  Device #0: API: OpenCL. GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 3069/3137 Mb.
  Device #1: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 7514 Mb.
Using device #0: API: OpenCL. GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 3069/3137 Mb.
Using OpenCL API...
Matrix size: rows=H=8192 x cols=W=16384 (512 MB)
______________________________________________________
Evaluating algorithm #1/2: 01 naive transpose (non-coalesced)
Kernels compilation done in 0.272752 seconds
algorithm times (in seconds) - 10 values (min=0.170015 10%=0.170539 median=0.175083 90%=0.593364 max=0.593364)
median effective algorithm bandwidth: 5.71158 GB/s                                                            
______________________________________________________
Evaluating algorithm #2/2: 02 transpose via local memory (coalesced)
Kernels compilation done in 0.438939 seconds
algorithm times (in seconds) - 10 values (min=0.155474 10%=0.157204 median=0.162531 90%=0.74197 max=0.74197)
median effective algorithm bandwidth: 6.15268 GB/s

$ ./main_matrix_multiply
Found 2 GPUs in 0.212095 sec (OpenCL: 0.151997 sec, Vulkan: 0.0597343 sec)    
Available devices:                                                            
  Device #0: API: OpenCL. GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 3069/3137 Mb.                                 
  Device #1: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 7514 Mb.
Using device #0: API: OpenCL. GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 3069/3137 Mb.
Using OpenCL API...
C = A x B, matrices size: C (rows=H=2048 x cols=W=4096) = A (rows=H=2048 x cols=K=1024) x B (rows=K=1024 x cols=W=4096)
matrices data size: A - 8 MB, B - 16 MB, C - 16 MB
______________________________________________________
Evaluating algorithm #1/3: CPU with OpenMP
algorithm times (in seconds) - 1 values (min=16.8321 10%=16.8321 median=16.8321 90%=16.8321 max=16.8321)
algorithm GFlops: 1.02016 GFlops                                                                        
algorithm effective memory bandwidth: 0.003249 GB/s                                                     
______________________________________________________                                                  
Evaluating algorithm #2/3: 01 naive                                                                     
Kernels compilation done in 0.0863511 seconds
algorithm times (in seconds) - 10 values (min=0.563561 10%=0.564931 median=0.573185 90%=0.712614 max=0.712614)
algorithm GFlops: 29.958 GFlops                                                                               
algorithm effective memory bandwidth: 0.0954098 GB/s                                                          
relative differences with CPU: 8388608 values (min=0 10%=0 median=0 90%=0 max=0)
median relative difference with CPU: 0                
99% percentile relative difference with CPU: 0        
______________________________________________________
Evaluating algorithm #3/3: 02 using local memory      
Kernels compilation done in 0.0590079 seconds
algorithm times (in seconds) - 10 values (min=0.211308 10%=0.213502 median=0.224496 90%=0.303139 max=0.303139)
algorithm GFlops: 76.4889 GFlops                                                                              
algorithm effective memory bandwidth: 0.243601 GB/s                                                           
relative differences with CPU: 8388608 values (min=0 10%=0 median=0 90%=0 max=0)
median relative difference with CPU: 0
99% percentile relative difference with CPU: 0
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_matrix_transpose
Found 2 GPUs in 0.0515368 sec (CUDA: 8.0741e-05 sec, OpenCL: 0.0241771 sec, Vulkan: 0.0272261 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15990 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15990/15990 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15990 Mb.
Using OpenCL API...
Matrix size: rows=H=[8](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810671670/job/66166944549#step:15:9)192 x cols=W=16384 (512 MB)
______________________________________________________
Evaluating algorithm #1/2: 01 naive transpose (non-coalesced)
Kernels compilation done in 0.11[9](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810671670/job/66166944549#step:15:10)772 seconds
algorithm times (in seconds) - 10 values (min=0.1644 10%=0.174158 median=0.20944 90%=0.296053 max=0.296053)
median effective algorithm bandwidth: 4.77464 GB/s
______________________________________________________
Evaluating algorithm #2/2: 02 transpose via local memory (coalesced)
Kernels compilation done in 0.0419922 seconds
algorithm times (in seconds) - [10](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810671670/job/66166944549#step:15:11) values (min=0.169447 10%=0.16961 median=0.169875 90%=0.214047 max=0.214047)
median effective algorithm bandwidth: 5.8867 GB/s

$ ./main_matrix_multiply
Found 2 GPUs in 0.0511717 sec (CUDA: 8.1863e-05 sec, OpenCL: 0.0236903 sec, Vulkan: 0.0273561 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15990 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15990/15990 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15990 Mb.
Using OpenCL API...
C = A x B, matrices size: C (rows=H=204[8](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810403574/job/66166198091#step:16:9) x cols=W=4096) = A (rows=H=2048 x cols=K=1024) x B (rows=K=1024 x cols=W=40[9](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810403574/job/66166198091#step:16:10)6)
matrices data size: A - 8 MB, B - 16 MB, C - 16 MB
______________________________________________________
Evaluating algorithm #1/3: CPU with OpenMP
algorithm times (in seconds) - 1 values (min=14.8991 [10](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810403574/job/66166198091#step:16:11)%=14.8991 median=14.8991 90%=14.8991 max=14.8991)
algorithm GFlops: 1.15252 GFlops
algorithm effective memory bandwidth: 0.00367052 GB/s
______________________________________________________
Evaluating algorithm #2/3: 01 naive
Kernels compilation done in 0.127516 seconds
algorithm times (in seconds) - 10 values (min=1.42624 10%=1.43796 median=1.45924 90%=1.664 max=1.664)
algorithm GFlops: [11](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810403574/job/66166198091#step:16:12).7674 GFlops
algorithm effective memory bandwidth: 0.0374766 GB/s
relative differences with CPU: 8388608 values (min=0 10%=0 median=2.21073e-07 90%=1.[12](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810403574/job/66166198091#step:16:13)363e-06 max=2.77294)
median relative difference with CPU: 2.21073e-07
99% percentile relative difference with CPU: 1.09303e-05
______________________________________________________
Evaluating algorithm #3/3: 02 using local memory
Kernels compilation done in 0.0652832 seconds
algorithm times (in seconds) - 10 values (min=1.41456 10%=1.41573 median=1.41781 90%=1.48529 max=1.48529)
algorithm GFlops: 12.11[13](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22810403574/job/66166198091#step:16:14) GFlops
algorithm effective memory bandwidth: 0.0385719 GB/s
relative differences with CPU: 8388608 values (min=0 10%=0 median=2.21073e-07 90%=1.12363e-06 max=2.77294)
median relative difference with CPU: 2.21073e-07
99% percentile relative difference with CPU: 1.09303e-05
</pre>

</p></details>