### PR TITLE
Task07 Denis Sokolov ITMO

### DIFF
--- a/src/kernels/cl/sparse_csr_matrix_vector_multiplication.cl
+++ b/src/kernels/cl/sparse_csr_matrix_vector_multiplication.cl
@@ -5,8 +5,37 @@
 #include "helpers/rassert.cl"
 #include "../defines.h"
 
-__attribute__((reqd_work_group_size(1, 1, 1)))
-__kernel void sparse_csr_matrix_vector_multiplication() // TODO input/output buffers
+__attribute__((reqd_work_group_size(GROUP_SIZE, 1, 1)))
+__kernel void sparse_csr_matrix_vector_multiplication(
+    __global const uint* row_offsets,
+    __global const uint* columns,
+    __global const uint* values,
+    __global const uint* input_vector,
+    __global uint* output_vector,
+    unsigned int  nrows,
+    unsigned int  ncols,
+    unsigned int  nnz)
 {
-    // TODO
+    const uint index = get_local_id(0);
+    const uint row = get_group_id(0);
+
+    __local uint tile[GROUP_SIZE];
+
+    const uint global_idx = row_offsets[row] + index;
+    const uint next_offset = (row + 1 < nrows) ? row_offsets[row + 1] : nnz;
+
+    const uint col = columns[global_idx];
+    tile[index] = global_idx < next_offset ? values[global_idx] * input_vector[col] : 0;
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (index != 0)
+        return;
+
+    unsigned int sum = 0;
+    for(unsigned int t = 0; t < GROUP_SIZE; ++t) {
+        sum += tile[t];
+    }
+
+    output_vector[row] = sum;
 }

--- a/src/main_csr_spmv.cpp
+++ b/src/main_csr_spmv.cpp
@@ -163,8 +163,19 @@ void run(int argc, char** argv)
             // Запускаем кернел, с указанием размера рабочего пространства и передачей всех аргументов
             // Если хотите - можете удалить ветвление здесь и оставить только тот код который соответствует вашему выбору API
             if (context.type() == gpu::Context::TypeOpenCL) {
-                // TODO
-                throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);
+                gpu::WorkSize ws(GROUP_SIZE, GROUP_SIZE * ncols);
+
+                ocl_spvm.exec(
+                    ws,
+                    csr_row_offsets_gpu,
+                    csr_columns_gpu,
+                    csr_values_gpu,
+                    vector_values_gpu,
+                    output_vector_values_gpu,
+                    nrows,
+                    ncols,
+                    nnz
+                );
             } else if (context.type() == gpu::Context::TypeCUDA) {
                 // TODO
                 throw std::runtime_error(CODE_IS_NOT_IMPLEMENTED);


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>

<pre>
$ ./main_sparse_matrix_multiply
Found 2 GPUs in 0.211759 sec (OpenCL: 0.138175 sec, Vulkan: 0.0727802 sec)    
Available devices:                                                            
  Device #0: API: OpenCL. GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 3069/3137 Mb.                                 
  Device #1: API: OpenCL. CPU. AMD Ryzen 5 5500U with Radeon Graphics         . Intel(R) Corporation. Total memory: 7514 Mb.
Using device #0: API: OpenCL. GPU. AMD Radeon(TM) Graphics (gfx902). Free memory: 3069/3137 Mb.                             
Using OpenCL API...                                                                                                         
Evaluating CSR matrix nrows x ncols=1000000x1000000 with values in range [0; 1000]          
____________________________________________________________________________________________
Evaluating with NNZ per row in range [32; 32], median NNZ per row=32, total NNZ=32000000...
CPU (multi-threaded via OpenMP) finished in 0.0572832 sec      
CPU effective bandwidth: 2.19343 GB/s (551.586 uint millions/s)
Kernels compilation done in 0.0779748 seconds
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.222917 10%=0.223147 median=0.224041 90%=0.306784 max=0.306784)
GPU SpMV median effective VRAM bandwidth: 0.565343 GB/s (142.831 uint millions/s)                                                                  
____________________________________________________________________________________________
Evaluating with NNZ per row in range [128; 128], median NNZ per row=128, total NNZ=128000000...
CPU (multi-threaded via OpenMP) finished in 0.506888 sec
CPU effective bandwidth: 0.874346 GB/s (230.939 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.420493 10%=0.422547 median=0.432062 90%=0.523749 max=0.523749)
GPU SpMV median effective VRAM bandwidth: 1.12088 GB/s (296.254 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [1; 32], median NNZ per row=17, total NNZ=16499998...
CPU (multi-threaded via OpenMP) finished in 0.036304 sec
CPU effective bandwidth: 1.85481 GB/s (424.948 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.222726 10%=0.222782 median=0.223535 90%=0.224793 max=0.224793)
GPU SpMV median effective VRAM bandwidth: 0.308309 GB/s (71.5771 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [1; 128], median NNZ per row=64, total NNZ=64499934...
CPU (multi-threaded via OpenMP) finished in 0.142101 sec
CPU effective bandwidth: 1.73679 GB/s (445.96 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.229239 10%=0.229381 median=0.234751 90%=0.267188 max=0.267188)
GPU SpMV median effective VRAM bandwidth: 1.0553 GB/s (272.63 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [32; 128], median NNZ per row=80, total NNZ=79933808...
CPU (multi-threaded via OpenMP) finished in 0.159288 sec
CPU effective bandwidth: 1.9101 GB/s (493.638 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.271417 10%=0.274579 median=0.315918 90%=0.34568 max=0.34568)
GPU SpMV median effective VRAM bandwidth: 0.96616 GB/s (250.065 uint millions/s)
</pre>

</p></details>

<details><summary>Вывод Github CI</summary><p>

<pre>
$ ./main_sparse_matrix_multiply
Found 2 GPUs in 0.0578978 sec (CUDA: 8.7642e-05 sec, OpenCL: 0.0282925 sec, Vulkan: 0.0294639 sec)
Available devices:
  Device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15994 Mb.
  Device #1: API: Vulkan. CPU. llvmpipe (LLVM 20.1.2, 256 bits). Free memory: 15994/15994 Mb.
Using device #0: API: OpenCL. CPU. AMD EPYC 7763 64-Core Processor                . Intel(R) Corporation. Total memory: 15994 Mb.
Using OpenCL API...
Evaluating CSR matrix nrows x ncols=1000000x1000000 with values in range [0; 1000]
____________________________________________________________________________________________
Evaluating with NNZ per row in range [32; 32], median NNZ per row=32, total NNZ=32000000...
CPU (multi-threaded via OpenMP) finished in 0.029[8](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:9)864 sec
CPU effective bandwidth: 4.23377 GB/s (106[9](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:10).6 uint millions/s)
Kernels compilation done in 0.129737 seconds
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - [10](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:11) values (min=0.289951 10%=0.290186 median=0.291467 90%=0.467056 max=0.467056)
GPU SpMV median effective VRAM bandwidth: 0.43456 GB/s (109.789 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [128; 128], median NNZ per row=128, total NNZ=128000000...
CPU (multi-threaded via OpenMP) finished in 0.0684338 sec
CPU effective bandwidth: 7.07314 GB/s (1869.45 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.373149 10%=0.374616 median=0.380655 90%=0.438381 max=0.438381)
GPU SpMV median effective VRAM bandwidth: 1.27225 GB/s (336.263 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [1; 32], median NNZ per row=17, total NNZ=16499998...
CPU (multi-threaded via OpenMP) finished in 0.0143547 sec
CPU effective bandwidth: 4.79126 GB/s ([11](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:12)12.27 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.282293 10%=0.282771 median=0.28363 90%=0.298394 max=0.298394)
GPU SpMV median effective VRAM bandwidth: 0.242985 GB/s (56.4116 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [1; [12](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:13)8], median NNZ per row=64, total NNZ=64499934...
CPU (multi-threaded via OpenMP) finished in 0.0375956 sec
CPU effective bandwidth: 6.58347 GB/s (1700.76 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.328957 10%=0.329019 median=0.330702 90%=0.333874 max=0.333874)
GPU SpMV median effective VRAM bandwidth: 0.749107 GB/s (193.528 uint millions/s)
____________________________________________________________________________________________
Evaluating with NNZ per row in range [32; 128], median NNZ per row=80, total NNZ=8001[14](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:15)95...
CPU (multi-threaded via OpenMP) finished in 0.0470027 sec
CPU effective bandwidth: 6.49465 GB/s (1700.6 uint millions/s)
GPU SpMV (sparse matrix-vector multiplication) times (in seconds) - 10 values (min=0.34371 10%=0.344303 median=0.345997 90%=0.349866 max=0.349866)
GPU SpMV median effective VRAM bandwidth: 0.883003 GB/s (231.2[16](https://github.com/GPGPUCourse/GPGPUTasks2025/actions/runs/22972272745/job/66691828238#step:16:17) uint millions/s)
</pre>

</p></details>